### PR TITLE
fix: add **/.tmp/ to .gitignore to prevent sails-disk db from being committed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ src/sw-cache
 .env
 .env.local
 restaurant-server/config/local.js
+**/.tmp/


### PR DESCRIPTION
## Summary

- Adds `**/.tmp/` to `.gitignore` so Sails.js's runtime database file (`restaurant-server/.tmp/localDiskDb.db`) is never accidentally committed
- Prevents churn from the sails-disk adapter regenerating the file on every run

Closes #11

## Test plan
- [ ] Run `restaurant-server` and confirm `restaurant-server/.tmp/localDiskDb.db` is untracked (`git status` shows nothing for it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)