### PR TITLE
fix: resolve API port mismatch between front-end and Sails server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 GOOGLE_MAPS_API_KEY=
 SESSION_SECRET=
 CORS_ORIGIN=http://localhost:8080
+API_SERVER=http://localhost:1337

--- a/src/js/dbhelper.js
+++ b/src/js/dbhelper.js
@@ -1,6 +1,6 @@
 import { getItems, getItem, writeItem } from "./utils";
 
-const SERVER = "http://localhost:1338";
+const SERVER = process.env.API_SERVER || "http://localhost:1337";
 
 export async function fetchRestaurants() {
   try {


### PR DESCRIPTION
## Summary

- `src/js/dbhelper.js` hardcoded `http://localhost:1338` but `serve:api` starts Sails on its default port **1337**, so every API request silently failed and the app fell back to its IDB cache
- Replace the hardcoded string with `process.env.API_SERVER || "http://localhost:1337"` — the existing `dotenv-webpack` setup already injects `.env` variables into the front-end bundle
- Document `API_SERVER` in `.env.example` so developers know the knob exists

## Test plan

- [ ] Start the API with `npm run serve:api` (default port 1337)
- [ ] Start the dev front-end with `npm run dev:ui`
- [ ] Confirm restaurants and reviews load from the live API (not just the IDB cache)
- [ ] Optionally set `API_SERVER=http://localhost:XXXX` in `.env` and confirm the front-end respects it

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)