### PR TITLE
fix: correct mojibake in seed data and add favicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,28 @@ The app will open in Chrome automatically, but the browser loads before the back
 
 This will install and start the production build of the app.
 
+#### Environment variables
+
+Copy `.env.example` to `.env` and fill in the values before starting:
+
+| Variable | Purpose | Example |
+|---|---|---|
+| `GOOGLE_MAPS_API_KEY` | Google Maps embed | *(your key)* |
+| `SESSION_SECRET` | Sails session signing — **required** to start the API | any random string |
+| `CORS_ORIGIN` | Allowed front-end origin for the API | `http://localhost:7000` |
+| `API_SERVER` | Front-end base URL for the API | `http://localhost:1337` |
+
+The API server (`restaurant-server/app.js`) exits immediately if `SESSION_SECRET` is not set.
+
+#### Re-seeding the database
+
+The API seeds restaurants and reviews on first launch against an empty store. If you need to reset to the bundled seed data (e.g. after a seed-data fix), delete the Sails-disk database and restart:
+
+```bash
+rm -rf restaurant-server/.tmp/localDiskDb
+npm run serve:api
+```
+
 Please note that I'm using Webpack twice, first to bundle my service worker and then to bundle and build my entire app. I do two separate passes because the service worker needs to be built and bundled before being used by Workbox's `InjectManifest` plugin. I did considerable research to see if there was a cleaner solution to using ESM modules in my service worker in conjuction with Workbox and Webpack, and I didn't really find anything.
 
 I've included my Lighthouse Report in case we have differing results.

--- a/restaurant-server/config/seed-data.json
+++ b/restaurant-server/config/seed-data.json
@@ -273,7 +273,7 @@
       "createdAt": "2018-06-03T19:24:26.708Z",
       "updatedAt": "2018-06-03T19:24:26.708Z",
       "rating": 4,
-      "comments": "Mission Chinese Food has grown up from its scrappy Orchard Street days into a big, two story restaurant equipped with a pizza oven, a prime rib cart, and a much broader menu. Yes, it still has all the hits â€” the kung pao pastrami, the thrice cooked bacon â€”but chef/proprietor Danny Bowien and executive chef Angela Dimayuga have also added a raw bar, two generous family-style set menus, and showstoppers like duck baked in clay. And you can still get a lot of food without breaking the bank."
+      "comments": "Mission Chinese Food has grown up from its scrappy Orchard Street days into a big, two story restaurant equipped with a pizza oven, a prime rib cart, and a much broader menu. Yes, it still has all the hits — the kung pao pastrami, the thrice cooked bacon —but chef/proprietor Danny Bowien and executive chef Angela Dimayuga have also added a raw bar, two generous family-style set menus, and showstoppers like duck baked in clay. And you can still get a lot of food without breaking the bank."
     },
     {
       "id": 2,
@@ -327,7 +327,7 @@
       "createdAt": "2018-06-03T19:24:26.708Z",
       "updatedAt": "2018-06-03T19:24:26.708Z",
       "rating": 4,
-      "comments": "The tables at this 32nd Street favorite are outfitted with grills for cooking short ribs, brisket, beef tongue, rib eye, and pork jowl. The banchan plates are uniformly good, and Deuki Hongâ€™s menu also includes winning dishes like stir-fried squid noodles, kimchi stew, and seafood pancakes. If itâ€™s available, make sure to order the kimchi and rice â€œlunchbox.â€ Baekjeong is a great place for large groups and birthday parties."
+      "comments": "The tables at this 32nd Street favorite are outfitted with grills for cooking short ribs, brisket, beef tongue, rib eye, and pork jowl. The banchan plates are uniformly good, and Deuki Hong’s menu also includes winning dishes like stir-fried squid noodles, kimchi stew, and seafood pancakes. If it’s available, make sure to order the kimchi and rice “lunchbox.â€ Baekjeong is a great place for large groups and birthday parties."
     },
     {
       "id": 8,
@@ -354,7 +354,7 @@
       "createdAt": "2018-06-03T19:24:26.708Z",
       "updatedAt": "2018-06-03T19:24:26.708Z",
       "rating": 5,
-      "comments": "In 127 years, little has changed at Katz's. It remains one of New York's â€” and the country's â€” essential Jewish delicatessens. Every inch of the massive Lower East Side space smells intensely of pastrami and rye loaves. The sandwiches are massive, so they are best when shared. Order at the counter, and don't forget to tip your slicer â€” your sandwich will be better for it."
+      "comments": "In 127 years, little has changed at Katz's. It remains one of New York's — and the country's — essential Jewish delicatessens. Every inch of the massive Lower East Side space smells intensely of pastrami and rye loaves. The sandwiches are massive, so they are best when shared. Order at the counter, and don't forget to tip your slicer — your sandwich will be better for it."
     },
     {
       "id": 11,
@@ -435,7 +435,7 @@
       "createdAt": "2018-06-03T19:24:26.708Z",
       "updatedAt": "2018-06-03T19:24:26.708Z",
       "rating": 4,
-      "comments": "Brooks Headleyâ€™s tiny East Village cafe is so much more than a veggie burger spot â€” it's one of the best bang-for-your-buck restaurants in Lower Manhattan. Headley and his crew turn seasonal vegetables into delectable salads and riffs on American comfort food favorites. The specials menu changes daily, and the rest of the menu is constantly evolving. You can get a lot of food to eat here for under $15 per person."
+      "comments": "Brooks Headley’s tiny East Village cafe is so much more than a veggie burger spot — it's one of the best bang-for-your-buck restaurants in Lower Manhattan. Headley and his crew turn seasonal vegetables into delectable salads and riffs on American comfort food favorites. The specials menu changes daily, and the rest of the menu is constantly evolving. You can get a lot of food to eat here for under $15 per person."
     },
     {
       "id": 20,
@@ -462,7 +462,7 @@
       "createdAt": "2018-06-03T19:24:26.708Z",
       "updatedAt": "2018-06-03T19:24:26.708Z",
       "rating": 4,
-      "comments": "Over the last five years, The Dutch has turned into the quintessential American restaurant that chef Andrew Carmellini and partners Josh Pickard and Luke Ostrom sought to evoke when it first opened. Itâ€™s a great choice when youâ€™re craving a steak, a burger, or oysters, and the menu always includes plentiful seafood options as well as pastas. The Dutch is now an indelible part of the Soho landscape."
+      "comments": "Over the last five years, The Dutch has turned into the quintessential American restaurant that chef Andrew Carmellini and partners Josh Pickard and Luke Ostrom sought to evoke when it first opened. It’s a great choice when you’re craving a steak, a burger, or oysters, and the menu always includes plentiful seafood options as well as pastas. The Dutch is now an indelible part of the Soho landscape."
     },
     {
       "id": 23,
@@ -489,7 +489,7 @@
       "createdAt": "2018-06-03T19:24:26.708Z",
       "updatedAt": "2018-06-03T19:24:26.708Z",
       "rating": 4,
-      "comments": "Joshua Smooklerâ€™s two-year-old ramen shop serves one of the best tonkotsu broths around. Beyond ramen, Mu also offers some high minded plates, like foie gras-stuffed chicken wings, as well as dry-aged Japanese Wagyu beef specials. Mu is just 10 short minutes away from Midtown via the 7-train."
+      "comments": "Joshua Smookler’s two-year-old ramen shop serves one of the best tonkotsu broths around. Beyond ramen, Mu also offers some high minded plates, like foie gras-stuffed chicken wings, as well as dry-aged Japanese Wagyu beef specials. Mu is just 10 short minutes away from Midtown via the 7-train."
     },
     {
       "id": 26,

--- a/src/index.html
+++ b/src/index.html
@@ -14,6 +14,7 @@
   <link rel="apple-touch-icon" href="/img/icons/apple-touch-icon-120x120.png" sizes="120x120">
   <link rel="apple-touch-icon" href="/img/icons/apple-touch-icon-152x152.png" sizes="152x152">
   <meta name="theme-color" content="#3f51b5">
+  <link rel="icon" type="image/png" sizes="96x96" href="/img/icons/icon-96x96.png">
 </head>
 
 <body>

--- a/src/restaurant.html
+++ b/src/restaurant.html
@@ -14,6 +14,7 @@
   <link rel="apple-touch-icon" href="/img/icons/apple-touch-icon-120x120.png" sizes="120x120">
   <link rel="apple-touch-icon" href="/img/icons/apple-touch-icon-152x152.png" sizes="152x152">
   <meta name="theme-color" content="#3f51b5">
+  <link rel="icon" type="image/png" sizes="96x96" href="/img/icons/icon-96x96.png">
 </head>
 
 <body class="inside">

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -22,7 +22,8 @@ module.exports = merge(common, {
     new CleanWebpackPlugin(["dist"]),
     new CopyWebpackPlugin([
       "./src/manifest.json",
-      { from: "./src/img/icons/*", to: "./img/icons/", flatten: true }
+      { from: "./src/img/icons/*", to: "./img/icons/", flatten: true },
+      { from: "./src/img/icons/icon-96x96.png", to: "./favicon.ico", toType: "file" }
     ]),
     new HtmlWebpackPlugin({
       template: "./src/index.html",

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -36,7 +36,8 @@ module.exports = merge(common, {
     new CleanWebpackPlugin(["dist"]),
     new CopyWebpackPlugin([
       "./src/manifest.json",
-      { from: "./src/img/icons/*", to: "./img/icons/", flatten: true }
+      { from: "./src/img/icons/*", to: "./img/icons/", flatten: true },
+      { from: "./src/img/icons/icon-96x96.png", to: "./favicon.ico", toType: "file" }
     ]),
     new HtmlWebpackPlugin({
       chunks: ["main", "main~restaurantInfo"],


### PR DESCRIPTION
## Summary

- Fixes 13 double-encoded smart punctuation characters (em dashes, curly quotes) in `restaurant-server/config/seed-data.json`. The UTF-8 bytes for each character were misread as Windows-1252 and re-saved as UTF-8, producing garbled sequences like `â€"` instead of `—`.
- Adds `<link rel="icon" type="image/png" sizes="96x96" href="/img/icons/icon-96x96.png">` to both HTML templates so modern browsers use the existing icon.
- Copies `icon-96x96.png` to `dist/favicon.ico` via `CopyWebpackPlugin` in both dev and prod configs, eliminating the 404 on every page load.

## Test plan

- [ ] Start the API server and front-end, open a restaurant detail page (e.g. restaurant 1), confirm the first review reads `... all the hits — the kung pao pastrami ...` with a proper em dash.
- [ ] Check browser DevTools Network tab — no more 404 on `/favicon.ico`.
- [ ] Verify the browser tab shows the restaurant icon.

Closes #23
Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)