### PR TITLE
fix: use autoIncrement key for sync-reviews IDB store to prevent draft collisions

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -1,15 +1,16 @@
 import * as idb from "idb";
 
-const dbPromise = idb.open("restaurants-store", 6, db => {
+const dbPromise = idb.open("restaurants-store", 7, db => {
   if (!db.objectStoreNames.contains("restaurants")) {
     db.createObjectStore("restaurants", { keyPath: "id" });
   }
   if (!db.objectStoreNames.contains("reviews")) {
     db.createObjectStore("reviews", { keyPath: "id" });
   }
-  if (!db.objectStoreNames.contains("sync-reviews")) {
-    db.createObjectStore("sync-reviews", { keyPath: ["name", "restaurant_id"] });
+  if (db.objectStoreNames.contains("sync-reviews")) {
+    db.deleteObjectStore("sync-reviews");
   }
+  db.createObjectStore("sync-reviews", { keyPath: "localId", autoIncrement: true });
 });
 
 export async function writeItem(storeName, item) {

--- a/src/sw.base.mjs
+++ b/src/sw.base.mjs
@@ -195,10 +195,7 @@ function syncNewReviews() {
           .then(resBody => {
             // and delete the review from the sync-reviews store if successful
             console.log(`[SW] Synced review with server`, resBody);
-            return deleteItem("sync-reviews", [
-              resBody.name,
-              resBody.restaurant_id
-            ]);
+            return deleteItem("sync-reviews", review.localId);
           })
           .catch(err => {
             console.log(`[SW] Error syncing review ${review.name}`, err);


### PR DESCRIPTION
## Summary

- Replaces the composite `keyPath: ["name", "restaurant_id"]` on the `sync-reviews` IndexedDB store with `keyPath: "localId", autoIncrement: true`
- Bumps the IDB schema version from 6 → 7 with a migration that drops and recreates the store
- Updates the service-worker `syncNewReviews` handler to delete by `review.localId` after a successful POST instead of the old composite key

## Why

Two drafts from the same reviewer for the same restaurant shared the same composite key, so the second `put()` silently overwrote the first draft before it could sync.

## Test plan

- [ ] Submit two reviews as the same name for the same restaurant while offline; verify both appear as pending drafts
- [ ] Go online and confirm both reviews sync and the `sync-reviews` store is cleared
- [ ] Verify existing browsers with the old v6 schema migrate cleanly (store is recreated on first load)

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)