### PR TITLE
fix: try direct POST first in postReview, fall back to SyncManager on network failure

### DIFF
--- a/src/js/dbhelper.js
+++ b/src/js/dbhelper.js
@@ -76,10 +76,14 @@ export async function postReviewViaSyncManager(body) {
 }
 
 export async function postReview(body) {
-  if ("serviceWorker" in navigator && "SyncManager" in window) {
-    return postReviewViaSyncManager(body);
+  try {
+    return await postReviewDirectly(body);
+  } catch (e) {
+    if ("serviceWorker" in navigator && "SyncManager" in window) {
+      return postReviewViaSyncManager(body);
+    }
+    throw e;
   }
-  return postReviewDirectly(body);
 }
 
 export async function postReviewDirectly(body) {


### PR DESCRIPTION
## Summary

- `postReview` previously always routed through `postReviewViaSyncManager` whenever `SyncManager` was available (most Chromium browsers), leaving submitted reviews as local drafts indefinitely if the `sync` event was deferred or throttled by the browser.
- Now `postReview` attempts a direct POST first and only falls back to queuing a Background Sync draft when the network request actually fails.
- No behaviour change for browsers without `SyncManager` (still throws on failure).

Fixes #20.

## Test plan

- [ ] Submit a review while online — verify it POSTs directly and appears immediately (no `isDraft` flag).
- [ ] Submit a review while offline (DevTools → Network → Offline) — verify it is queued in IDB `sync-reviews` and synced when connectivity is restored.
- [ ] Verify that reviews posted directly are not duplicated when the service worker's `sync-new-reviews` handler fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)