### PR TITLE
fix: always refresh review list after postReview resolves

### DIFF
--- a/src/js/restaurant_info.js
+++ b/src/js/restaurant_info.js
@@ -159,9 +159,7 @@ const CRM = new CreateReviewModal({
   restaurantID: getParam("id"),
   onSubmit: async postBody => {
     await postReview(postBody);
-    if (!("SyncManager" in window)) {
-      window.setTimeout(() => fetchReviewsFromURL(), 500);
-    }
+    window.setTimeout(() => fetchReviewsFromURL(), 500);
   }
 });
 


### PR DESCRIPTION
## Summary

- Removes the inverted `!("SyncManager" in window)` guard from the `onSubmit` handler in `restaurant_info.js`
- After PR #32 changed `postReview` to attempt a direct POST first and only fall back to SyncManager on network failure, Chromium browsers (which have SyncManager) never triggered the review-list refresh after a successful online POST
- The fix unconditionally calls `fetchReviewsFromURL()` after `postReview` resolves — correct for both the online path (server review appears immediately) and the offline/draft path (IDB draft appears immediately since `fetchReviewsForRestaurant` already includes `sync-reviews` items)

Closes #33

## Test plan

- [ ] Submit a review while online on a Chromium browser — new review appears in the list within ~500 ms without a page reload
- [ ] Submit a review while offline — draft appears in the list immediately; disappears (replaced by the server copy) once background sync fires

## Verification

Verified manually with Playwright against `http://localhost:8080`:
- Before fix: 13 reviews, submit → still 13 (list not refreshed)
- After fix: 13 reviews, submit → 14 reviews with the new entry at the bottom, no reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)