### PR TITLE
fix: strip localId from review body before syncing to server

### DIFF
--- a/src/sw.base.mjs
+++ b/src/sw.base.mjs
@@ -146,7 +146,8 @@ function syncNewReviews() {
   return getItems("sync-reviews").then(reviews => {
     if (reviews && reviews.length > 0) {
       const arrOfPromises = reviews.map(review => {
-        return postReviewDirectly(review)
+        const { localId, ...reviewBody } = review;
+        return postReviewDirectly(reviewBody)
           .then(resBody => {
             console.log(`[SW] Synced review with server`, resBody);
             return deleteItem("sync-reviews", review.localId);


### PR DESCRIPTION
## Summary

- Destructures `localId` out of each IDB record in `syncNewReviews` before passing the body to `postReviewDirectly`
- `localId` is an IDB auto-increment key and an implementation detail that should never leave the client
- `review.localId` is still referenced for the subsequent `deleteItem` call, so cleanup is unaffected

Closes #37

## Test plan

- [ ] Submit a review while offline
- [ ] Come back online and verify the background sync fires
- [ ] Confirm the POST body sent to `localhost:1337/reviews` contains only `name`, `restaurant_id`, `rating`, `comments` — no `localId`
- [ ] Confirm the review appears correctly in the list after sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)