### PR TITLE
fix: fall back to network when restaurant.html not in cache

### DIFF
--- a/src/sw.base.mjs
+++ b/src/sw.base.mjs
@@ -1,6 +1,6 @@
 import { registerRoute } from "workbox-routing";
 import { StaleWhileRevalidate } from "workbox-strategies";
-import { precacheAndRoute } from "workbox-precaching";
+import { precacheAndRoute, matchPrecache } from "workbox-precaching";
 import { ExpirationPlugin } from "workbox-expiration";
 import {
   deleteItem,
@@ -33,7 +33,7 @@ registerRoute(
 registerRoute(
   /restaurant\.html\?id=[0-9]+/,
   async () => {
-    const cached = await caches.match("/restaurant.html");
+    const cached = await matchPrecache("/restaurant.html");
     return cached ?? fetch("/restaurant.html");
   }
 );

--- a/src/sw.base.mjs
+++ b/src/sw.base.mjs
@@ -32,7 +32,10 @@ registerRoute(
 // Redirect restaurant detail routes to pre-cached restaurant.html
 registerRoute(
   /restaurant\.html\?id=[0-9]+/,
-  () => caches.match("/restaurant.html")
+  async () => {
+    const cached = await caches.match("/restaurant.html");
+    return cached ?? fetch("/restaurant.html");
+  }
 );
 
 // Cache restaurant images


### PR DESCRIPTION
## Summary

- Fixes `ERR_FAILED` on cold-cache navigations to `/restaurant.html?id=*`
- When `caches.match("/restaurant.html")` returns `undefined`, the route handler now falls back to `fetch("/restaurant.html")` instead of resolving to `undefined`
- Cached shell is still served on repeat visits; network is only hit when the cache is cold

Closes #39

## Test plan

- [ ] Clear site data, load the app in a new profile
- [ ] Navigate to a restaurant detail page before precache finishes — confirm page loads instead of `ERR_FAILED`
- [ ] On a warm cache, confirm `/restaurant.html?id=*` still loads from cache (no network request for the shell)

🤖 Generated with [Claude Code](https://claude.com/claude-code)