### PR TITLE
fix: reset notifiedClient per syncNewReviews invocation

### DIFF
--- a/src/sw.base.mjs
+++ b/src/sw.base.mjs
@@ -146,6 +146,7 @@ const SUBMIT_REVIEWS_TIMEOUT = 1000;
 let notifiedClient = false;
 
 function syncNewReviews() {
+  notifiedClient = false;
   return getItems("sync-reviews").then(reviews => {
     if (reviews && reviews.length > 0) {
       const arrOfPromises = reviews.map(review => {


### PR DESCRIPTION
## Summary

- `notifiedClient` was a module-level flag initialized once at SW startup and never reset between sync events
- After the first sync set it to `true`, the `if (!notifiedClient)` guards in the timeout fallback and `.catch()` error path silently skipped sending `"refresh"` to the page on all subsequent invocations
- Fix: reset the flag to `false` at the top of `syncNewReviews()` so it tracks the current sync event rather than the SW module lifetime

Closes #36.

## Test plan

- [ ] Submit a review while offline → go online → verify page refreshes (success path, was never broken)
- [ ] Submit a review while offline → go online with API unreachable → verify page still receives `"refresh"` (error path, now fixed)
- [ ] Repeat the above two cycles back-to-back to confirm second-cycle behavior matches first

🤖 Generated with [Claude Code](https://claude.com/claude-code)