### PR TITLE
fix(docker): update Dockerfile for pnpm workspace

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+# Dependency directories — pnpm installs these inside the container
+node_modules
+restaurant-server/node_modules
+
+# Frontend source and build output — not needed for the server image
+src
+dist
+
+# Sails temp files
+.tmp
+restaurant-server/.tmp
+
+# Version control and tooling
+.git
+.claude

--- a/restaurant-server/.dockerignore
+++ b/restaurant-server/.dockerignore
@@ -1,3 +1,0 @@
-node_modules
-.tmp
-.git

--- a/restaurant-server/Dockerfile
+++ b/restaurant-server/Dockerfile
@@ -20,4 +20,6 @@ WORKDIR /app/restaurant-server
 
 EXPOSE 1337
 
+# Required at runtime: SESSION_SECRET
+# docker run -e SESSION_SECRET=<value> ...
 CMD ["node", "server"]

--- a/restaurant-server/Dockerfile
+++ b/restaurant-server/Dockerfile
@@ -1,16 +1,23 @@
-FROM node:18
+FROM node:24
 
-# Set the working directory to /app
+RUN corepack enable
+
 WORKDIR /app
 
-# Install project dependencies first to leverage Docker layer caching
-COPY package.json package-lock.json ./
-RUN npm ci --omit=dev
+# Copy workspace manifests, lockfile, and npmrc for layer caching.
+# Build context must be the monorepo root so pnpm-lock.yaml is accessible:
+#   docker build -f restaurant-server/Dockerfile .
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+COPY restaurant-server/package.json ./restaurant-server/
 
-# Copy the rest of the application source
-COPY . .
+# Install only production dependencies for this workspace package
+RUN pnpm install --prod --frozen-lockfile --filter Restaurant-Reviews
+
+# Copy the application source
+COPY restaurant-server/ ./restaurant-server/
+
+WORKDIR /app/restaurant-server
 
 EXPOSE 1337
 
-# Start the server when the container launches
 CMD ["node", "server"]


### PR DESCRIPTION
## Summary

- Removes reference to `package-lock.json` (deleted in the pnpm migration)
- Replaces `npm ci` with `pnpm install --prod --frozen-lockfile --filter Restaurant-Reviews`
- Adds `corepack enable` so pnpm is available without a separate install step
- Updates base image from `node:18` → `node:24` to match `.node-version`
- Changes build context from `restaurant-server/` to the monorepo root so `pnpm-lock.yaml` is accessible; build with: `docker build -f restaurant-server/Dockerfile .`

Closes #45

## Test plan

- [ ] `docker build -f restaurant-server/Dockerfile .` succeeds from the repo root
- [ ] Container starts and responds on port 1337

🤖 Generated with [Claude Code](https://claude.com/claude-code)