### PR TITLE
fix: catch sync.register failure in postReviewViaSyncManager

### DIFF
--- a/src/js/dbhelper.js
+++ b/src/js/dbhelper.js
@@ -71,8 +71,13 @@ export async function fetchCuisines() {
 
 export async function postReviewViaSyncManager(body) {
   await writeItem("sync-reviews", body);
-  const sw = await navigator.serviceWorker.ready;
-  await sw.sync.register("sync-new-reviews");
+  try {
+    const sw = await navigator.serviceWorker.ready;
+    await sw.sync.register("sync-new-reviews");
+  } catch (e) {
+    // SW not yet activated; draft is in IDB and will sync on next activation
+    console.warn("[App] Background sync registration failed; draft saved locally:", e.message);
+  }
 }
 
 export async function postReview(body) {


### PR DESCRIPTION
## Summary

- Wraps `sw.sync.register()` in a try/catch in `postReviewViaSyncManager`
- On `InvalidStateError` (SW installing/waiting, not yet activated), logs a `console.warn` instead of letting the rejection propagate unhandled
- The draft is safely written to IDB before the registration attempt, so no data is lost — it will sync on next SW activation

Closes #34

## Test plan

- [ ] Normal online review submission still works
- [ ] Simulate offline + freshly-installed SW: submit a review, confirm no unhandled rejection in console and a `[App] Background sync registration failed` warning appears instead
- [ ] After SW activates, confirm the queued IDB draft syncs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)