### PR TITLE
Replace Google Maps with Leaflet + OpenStreetMap

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -10,8 +10,9 @@
     {
       "name": "dev",
       "runtimeExecutable": "npx",
-      "runtimeArgs": ["webpack-dev-server", "--config", "webpack.dev.js"],
-      "port": 8080
+      "runtimeArgs": ["webpack", "serve", "--config", "webpack.dev.js", "--port", "8081"],
+      "port": 8081,
+      "autoPort": false
     },
     {
       "name": "api",

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,3 @@
-GOOGLE_MAPS_API_KEY=
 SESSION_SECRET=
 CORS_ORIGIN=http://localhost:8080
 API_SERVER=http://localhost:1337

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ Copy `.env.example` to `.env` and fill in the values before starting:
 
 | Variable | Purpose | Example |
 |---|---|---|
-| `GOOGLE_MAPS_API_KEY` | Google Maps embed | *(your key)* |
 | `SESSION_SECRET` | Sails session signing — **required** to start the API | any random string |
 | `CORS_ORIGIN` | Allowed front-end origin for the API | `http://localhost:7000` |
 | `API_SERVER` | Front-end base URL for the API | `http://localhost:1337` |

--- a/package.json
+++ b/package.json
@@ -53,8 +53,8 @@
     "workbox-webpack-plugin": "^7.3.0"
   },
   "dependencies": {
-    "google-maps": "^3.3.0",
     "idb": "^2.1.1",
+    "leaflet": "^1.9.4",
     "lit-html": "^0.10.0",
     "responsively-lazy": "^2.0.2"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,12 +8,12 @@ importers:
 
   .:
     dependencies:
-      google-maps:
-        specifier: ^3.3.0
-        version: 3.3.0
       idb:
         specifier: ^2.1.1
         version: 2.1.3
+      leaflet:
+        specifier: ^1.9.4
+        version: 1.9.4
       lit-html:
         specifier: ^0.10.0
         version: 0.10.2
@@ -2362,9 +2362,6 @@ packages:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
 
-  google-maps@3.3.0:
-    resolution: {integrity: sha512-pj4En0cWKG+lcBvC7qrzu5ItiMsYNTgjG2capsPzAbAM/O8ftugGpUUftTTwdGL8KlNvB4CEZ6IBWwpWYzUEpw==}
-
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -2788,6 +2785,9 @@ packages:
 
   launch-editor@2.14.0:
     resolution: {integrity: sha512-Pj3ZOx9dD1BClS7YcSQx0An1PCF9wz4JpvbEmKvDxQtm0jxlkk5NhW8x0SBAKA/acHBKZaqdd5FFOWlXo500JA==}
+
+  leaflet@1.9.4:
+    resolution: {integrity: sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==}
 
   leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
@@ -7140,8 +7140,6 @@ snapshots:
       define-properties: 1.2.1
       gopd: 1.2.0
 
-  google-maps@3.3.0: {}
-
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
@@ -7570,6 +7568,8 @@ snapshots:
     dependencies:
       picocolors: 1.1.1
       shell-quote: 1.8.4
+
+  leaflet@1.9.4: {}
 
   leven@3.1.0: {}
 

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -208,7 +208,7 @@ header {
   padding: 0;
   text-align: center;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(310px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(310px, 1fr));
 }
 #restaurants-list li {
   background-color: #fff;

--- a/src/js/RestaurantList/Restaurant/components/Heart.js
+++ b/src/js/RestaurantList/Restaurant/components/Heart.js
@@ -9,7 +9,7 @@ function Heart(height, width, isFavorite) {
     y="0px"
     width="${width}px"
     height="${height}px"
-    viewBox="0 0 32 29.6"
+    viewBox="-1 -1 34 31.6"
     fill="${isFavorite ? "red" : "transparent"}"
     stroke="black"
     >

--- a/src/js/dbhelper.js
+++ b/src/js/dbhelper.js
@@ -128,11 +128,3 @@ export function urlForRestaurant(restaurant) {
   return `./restaurant.html?id=${restaurant.id}`;
 }
 
-export function mapMarkerForRestaurant(restaurant, map) {
-  return new google.maps.Marker({
-    position: restaurant.latlng,
-    title: restaurant.name,
-    url: urlForRestaurant(restaurant),
-    map
-  });
-}

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -82,7 +82,7 @@ export const updateRestaurants = async () => {
     const restaurantListMountPoint = document.getElementById("restaurants-list");
     render(RestaurantList(filteredRestaurants), restaurantListMountPoint);
     if (window.state.map) {
-      window.state.markers.forEach(m => m.setMap(null));
+      window.state.markers.forEach(m => m.remove());
       window.state.markers = [];
       setMarkers(filteredRestaurants);
     }
@@ -99,7 +99,7 @@ toggleMapBtn.addEventListener("click", () => {
     mapContainer.style.height = "50vh";
     window.state.mapClosed = false;
     toggleMapBtn.setAttribute("aria-pressed", "true");
-    loadMap();
+    if (!window.state.map) loadMap();
   } else {
     mapContainer.style.height = "0vh";
     window.state.mapClosed = true;
@@ -107,4 +107,4 @@ toggleMapBtn.addEventListener("click", () => {
   }
 });
 
-navigator.serviceWorker.ready.then(sw => sw.sync.register("sync-new-reviews"));
+navigator.serviceWorker.ready.then(sw => sw.sync.register("sync-new-reviews")).catch(() => {});

--- a/src/js/mapsLoader.js
+++ b/src/js/mapsLoader.js
@@ -1,44 +1,45 @@
-import GoogleMapsLoader from "google-maps";
-import { mapMarkerForRestaurant } from "./dbhelper";
+import L from "leaflet";
+import "leaflet/dist/leaflet.css";
+import markerIcon from "leaflet/dist/images/marker-icon.png";
+import markerIcon2x from "leaflet/dist/images/marker-icon-2x.png";
+import markerShadow from "leaflet/dist/images/marker-shadow.png";
+import { urlForRestaurant } from "./dbhelper";
 
-const API_KEY = process.env.GOOGLE_MAPS_API_KEY || "";
+// Fix Leaflet's default icon paths broken by webpack's asset bundling
+delete L.Icon.Default.prototype._getIconUrl;
+L.Icon.Default.mergeOptions({
+  iconUrl: markerIcon,
+  iconRetinaUrl: markerIcon2x,
+  shadowUrl: markerShadow
+});
 
-if (!API_KEY) {
-  console.warn(
-    "GOOGLE_MAPS_API_KEY is not set. Set it in your environment before building; see .env.example."
-  );
+export function mapMarkerForRestaurant(restaurant, map) {
+  return L.marker([restaurant.latlng.lat, restaurant.latlng.lng], {
+    title: restaurant.name
+  })
+    .on("click", () => {
+      window.location.href = urlForRestaurant(restaurant);
+    })
+    .addTo(map);
 }
-
-GoogleMapsLoader.KEY = API_KEY;
 
 export function initMap(el, options) {
-  return new Promise(function(resolve, reject) {
-    try {
-      GoogleMapsLoader.load(function(google) {
-        window.state.map = new google.maps.Map(el, options);
-        window.google = google;
-        if (window.state.map && window.google) {
-          resolve(window.state.map);
-        } else {
-          reject("Unable to load Google Maps as expected");
-        }
-      });
-    } catch (e) {
-      reject(e);
-    }
+  const { lat, lng } = options.center;
+  const map = L.map(el, {
+    zoom: options.zoom,
+    center: [lat, lng],
+    scrollWheelZoom: false
   });
+  L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+    attribution: '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+  }).addTo(map);
+  window.state.map = map;
+  return Promise.resolve(map);
 }
 
-/**
- * Add markers for current restaurants to the map.
- */
 export const setMarkers = (restaurants, map = window.state.map) => {
   restaurants.forEach(restaurant => {
-    // Add marker to the map
     const marker = mapMarkerForRestaurant(restaurant, map);
-    window.google.maps.event.addListener(marker, "click", () => {
-      window.location.href = marker.url;
-    });
     window.state.markers.push(marker);
   });
 };

--- a/src/js/restaurant_info.js
+++ b/src/js/restaurant_info.js
@@ -1,11 +1,10 @@
 import {
-  mapMarkerForRestaurant,
   fetchRestaurantById,
   fetchReviewsForRestaurant,
   postReview
 } from "./dbhelper";
 import { getImage } from "./imageLoader";
-import { initMap } from "./mapsLoader";
+import { initMap, mapMarkerForRestaurant } from "./mapsLoader";
 import CreateReviewModal from "./CreateReviewModal";
 
 import "../css/normalize.css";
@@ -182,7 +181,7 @@ toggleMapBtn.addEventListener("click", () => {
     mapContainer.style.height = "50vh";
     window.state.mapClosed = false;
     toggleMapBtn.setAttribute("aria-pressed", "true");
-    loadMap();
+    if (!window.state.map) loadMap();
   } else {
     mapContainer.style.height = "0vh";
     window.state.mapClosed = true;
@@ -190,4 +189,4 @@ toggleMapBtn.addEventListener("click", () => {
   }
 });
 
-navigator.serviceWorker.ready.then(sw => sw.sync.register("sync-new-reviews"));
+navigator.serviceWorker.ready.then(sw => sw.sync.register("sync-new-reviews")).catch(() => {});

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -20,6 +20,11 @@ module.exports = {
       {
         test: /\.(svg|gif)$/,
         type: "asset/resource"
+      },
+      {
+        test: /\.(png|jpg)$/,
+        include: /node_modules/,
+        type: "asset/resource"
       }
     ]
   }

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -15,7 +15,10 @@ module.exports = merge(common, {
     restaurantInfo: "./src/js/restaurant_info.js"
   },
   devServer: {
-    static: "./dist"
+    static: "./dist",
+    client: {
+      overlay: { warnings: false, errors: true }
+    }
   },
   plugins: [
     new Dotenv({ systemvars: true }),
@@ -62,6 +65,7 @@ module.exports = merge(common, {
       },
       {
         test: /\.(jpg|png)$/i,
+        exclude: /node_modules/,
         loader: "responsive-loader",
         options: {
           adapter: require("responsive-loader/jimp")

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -89,6 +89,7 @@ module.exports = merge(common, {
       },
       {
         test: /\.(jpg|png)$/i,
+        exclude: /node_modules/,
         use: [
           {
             loader: "responsive-loader",


### PR DESCRIPTION
## Summary

- **No API key required**: swaps `google-maps` for `leaflet` with OpenStreetMap tiles; removes `GOOGLE_MAPS_API_KEY` from `.env.example` and docs
- **SW-safe architecture**: moves `mapMarkerForRestaurant` + Leaflet import into `mapsLoader.js` so `dbhelper.js` stays importable from the service worker without pulling in browser-only APIs
- **Bug fixes**: guards `loadMap()` so Leaflet never double-initialises the same container; silences unhandled background-sync rejections; switches restaurant grid from `auto-fit` → `auto-fill` so filtered cards stay a stable width; expands Heart SVG viewBox to prevent stroke clipping; suppresses the webpack-dev-server warning overlay in dev

## Test plan

- [ ] `pnpm install && pnpm start` (no `.env` needed beyond `SESSION_SECRET`)
- [ ] Toggle Map on the main page — OSM tiles and restaurant markers appear; clicking a marker navigates to the detail page
- [ ] Toggle Map on a restaurant detail page — single marker appears at the correct location
- [ ] Toggle Map open → close → open multiple times — no "Map container already initialized" error
- [ ] Apply a neighborhood + cuisine filter that returns fewer cards than a full row — cards stay at their column width, not stretched
- [ ] No unhandled promise rejections in the console on page load

🤖 Generated with [Claude Code](https://claude.ai/claude-code)