### PR TITLE
fix: push detail page map marker into window.state.markers

### DIFF
--- a/src/js/restaurant_info.js
+++ b/src/js/restaurant_info.js
@@ -45,7 +45,8 @@ function loadMap() {
     center: window.state.restaurant.latlng,
     scrollwheel: false
   }).then(() => {
-    mapMarkerForRestaurant(window.state.restaurant, window.state.map);
+    const marker = mapMarkerForRestaurant(window.state.restaurant, window.state.map);
+    window.state.markers.push(marker);
   });
 }
 


### PR DESCRIPTION
## Summary
- `loadMap()` on `restaurant.html` called `mapMarkerForRestaurant()` without capturing its return value, so `window.state.markers` stayed empty on the detail page
- Captured the returned marker and pushed it into `window.state.markers`, consistent with how `setMarkers()` handles the index page

Closes #49

## Test plan
- [ ] Visit a restaurant detail page — map marker still renders correctly
- [ ] Open DevTools console and verify `window.state.markers.length === 1` after the map loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)