### PR TITLE
fix: security, accessibility, and bug fixes

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -33,7 +33,7 @@
         </li>
       </ol>
     </nav>
-    <button tabindex="0" id="maptoggle" type="button" role="button" aria-label="Toggle Google Map" aria-pressed="false">Toggle Map</button>
+    <button tabindex="0" id="maptoggle" type="button" role="button" aria-label="Toggle map" aria-pressed="false">Toggle Map</button>
   </header>
 
   <main id="maincontent">

--- a/src/js/CreateReviewModal.js
+++ b/src/js/CreateReviewModal.js
@@ -87,7 +87,7 @@ export default class CreateReviewModal {
   handleKeyDown(e) {
     const KEY_TAB = 9;
     const KEY_ESC = 27;
-    const KEY_ENTER = 27;
+    const KEY_ENTER = 13;
 
     const handleBackwardTab = () => {
       if (document.activeElement === this.firstFocusableEl) {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -108,4 +108,6 @@ toggleMapBtn.addEventListener("click", () => {
   }
 });
 
-navigator.serviceWorker.ready.then(sw => sw.sync.register("sync-new-reviews")).catch(() => {});
+if ("serviceWorker" in navigator) {
+  navigator.serviceWorker.ready.then(sw => sw.sync.register("sync-new-reviews")).catch(() => {});
+}

--- a/src/js/restaurant_info.js
+++ b/src/js/restaurant_info.js
@@ -38,6 +38,45 @@ document.addEventListener("DOMContentLoaded", async () => {
     console.error(e);
   }
   fetchReviewsFromURL();
+
+  const CRM = new CreateReviewModal({
+    restaurantID: getParam("id"),
+    onSubmit: async postBody => {
+      await postReview(postBody);
+      window.setTimeout(() => fetchReviewsFromURL(), 500);
+    }
+  });
+
+  document.querySelector("#add-review-btn").addEventListener("click", () => CRM.open());
+
+  if ("serviceWorker" in navigator) {
+    navigator.serviceWorker.addEventListener("message", event => {
+      event.ports[0].postMessage("ACK");
+      if (event.data === "refresh") {
+        fetchReviewsFromURL();
+      }
+    });
+
+    navigator.serviceWorker.ready
+      .then(sw => sw.sync.register("sync-new-reviews"))
+      .catch(() => {});
+  }
+
+  const toggleMapBtn = document.querySelector("#maptoggle");
+  const mapContainer = document.querySelector("#map-container");
+
+  toggleMapBtn.addEventListener("click", () => {
+    if (window.state.mapClosed) {
+      mapContainer.style.height = "50vh";
+      window.state.mapClosed = false;
+      toggleMapBtn.setAttribute("aria-pressed", "true");
+      if (!window.state.map) loadMap();
+    } else {
+      mapContainer.style.height = "0vh";
+      window.state.mapClosed = true;
+      toggleMapBtn.setAttribute("aria-pressed", "false");
+    }
+  });
 });
 
 function loadMap() {
@@ -63,10 +102,10 @@ async function fetchRestaurantFromURL() {
 
 function fillRestaurantHTML(restaurant = window.state.restaurant) {
   const name = document.getElementById("restaurant-name");
-  name.innerHTML = restaurant.name;
+  name.textContent = restaurant.name;
 
   const address = document.getElementById("restaurant-address");
-  address.innerHTML = restaurant.address;
+  address.textContent = restaurant.address;
 
   const imageFile = getImage(restaurant.photograph);
   const image = document.getElementById("restaurant-img");
@@ -76,7 +115,7 @@ function fillRestaurantHTML(restaurant = window.state.restaurant) {
   image.src = imageFile.src;
 
   const cuisine = document.getElementById("restaurant-cuisine");
-  cuisine.innerHTML = restaurant.cuisine_type;
+  cuisine.textContent = restaurant.cuisine_type;
 
   if (restaurant.operating_hours) {
     fillRestaurantHoursHTML();
@@ -91,10 +130,10 @@ function fillRestaurantHoursHTML(
   for (let key in operatingHours) {
     const row = document.createElement("tr");
     const day = document.createElement("td");
-    day.innerHTML = key;
+    day.textContent = key;
     row.appendChild(day);
     const time = document.createElement("td");
-    time.innerHTML = operatingHours[key];
+    time.textContent = operatingHours[key];
     row.appendChild(time);
     hours.appendChild(row);
   }
@@ -155,40 +194,3 @@ function fillBreadcrumb(restaurant = window.state.restaurant) {
   li.appendChild(anchor);
   breadcrumb.appendChild(li);
 }
-
-const CRM = new CreateReviewModal({
-  restaurantID: getParam("id"),
-  onSubmit: async postBody => {
-    await postReview(postBody);
-    window.setTimeout(() => fetchReviewsFromURL(), 500);
-  }
-});
-
-document.querySelector("#add-review-btn").addEventListener("click", () => CRM.open());
-
-if ("serviceWorker" in navigator) {
-  navigator.serviceWorker.addEventListener("message", event => {
-    event.ports[0].postMessage("ACK");
-    if (event.data === "refresh") {
-      fetchReviewsFromURL();
-    }
-  });
-}
-
-const toggleMapBtn = document.querySelector("#maptoggle");
-const mapContainer = document.querySelector("#map-container");
-
-toggleMapBtn.addEventListener("click", () => {
-  if (window.state.mapClosed) {
-    mapContainer.style.height = "50vh";
-    window.state.mapClosed = false;
-    toggleMapBtn.setAttribute("aria-pressed", "true");
-    if (!window.state.map) loadMap();
-  } else {
-    mapContainer.style.height = "0vh";
-    window.state.mapClosed = true;
-    toggleMapBtn.setAttribute("aria-pressed", "false");
-  }
-});
-
-navigator.serviceWorker.ready.then(sw => sw.sync.register("sync-new-reviews")).catch(() => {});

--- a/src/restaurant.html
+++ b/src/restaurant.html
@@ -33,11 +33,11 @@
         </li>
       </ol>
     </nav>
-    <button tabindex="0" id="maptoggle" type="button" role="button" aria-label="Toggle Google Map" aria-pressed="false">Toggle Map</button>
+    <button tabindex="0" id="maptoggle" type="button" role="button" aria-label="Toggle map" aria-pressed="false">Toggle Map</button>
   </header>
 
   <main id="maincontent">
-    <section id="map-container" role="application" aria-roledescription="Google Maps" tabindex="-1">
+    <section id="map-container" role="application" aria-roledescription="Map" tabindex="-1">
       <div id="map"></div>
     </section>
     <section id="restaurant-container">


### PR DESCRIPTION
## Summary

- **#54** — Fix `KEY_ENTER` constant value (27→13) in `CreateReviewModal`; collided with `KEY_ESC`, making Enter handler dead code
- **#57** — Replace stale `aria-label="Toggle Google Map"` with `"Toggle map"` on both pages; update `aria-roledescription` from `"Google Maps"` to `"Map"`
- **#58** — Guard `navigator.serviceWorker.ready` behind `"serviceWorker" in navigator` in `main.js` and `restaurant_info.js` to prevent TypeError in private-browsing / non-SW contexts
- **#60** — Replace five `innerHTML` assignments with `textContent` for server-supplied restaurant fields to prevent XSS
- **#66** — Move `CreateReviewModal` instantiation, `#add-review-btn` listener, map-toggle wiring, and SW sync registration inside `DOMContentLoaded`

## Test plan

- [ ] Build succeeds: `pnpm run build:ui` exits 0
- [ ] Home page: "Toggle Map" button aria-label reads "Toggle map"
- [ ] Restaurant detail page: map section `aria-roledescription` reads "Map"
- [ ] Review modal: Escape closes it; Enter on Cancel button closes it
- [ ] Restaurant detail page loads with `?id=1` — name, address, cuisine render correctly
- [ ] `restaurant.html` without `?id` does not throw unhandled JS exceptions
- [ ] Page loads without TypeError in non-SW environments

Closes #54, #57, #58, #60, #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)