### PR TITLE
fix: service worker — cache OSM tiles and use env var for API server

### DIFF
--- a/src/sw.js
+++ b/src/sw.js
@@ -11,18 +11,19 @@ import {
 } from "./js/utils.js";
 import { postReviewDirectly } from "./js/dbhelper.js";
 
-const SERVER = `http://localhost:1337`;
+const SERVER = import.meta.env.API_SERVER || "http://localhost:1337";
+const SERVER_ORIGIN = new URL(SERVER).origin;
 
 precacheAndRoute(self.__WB_MANIFEST);
 
-// Cache Google fonts and map tiles
+// Cache OpenStreetMap tiles for offline map support
 registerRoute(
-  /.*(?:googleapis|gstatic)\.com.*$/,
+  ({ url }) => url.hostname.endsWith(".tile.openstreetmap.org"),
   new StaleWhileRevalidate({
-    cacheName: "google-maps",
+    cacheName: "map-tiles",
     plugins: [
       new ExpirationPlugin({
-        maxEntries: 3,
+        maxEntries: 500,
         maxAgeSeconds: 60 * 60 * 24 * 30
       })
     ]
@@ -74,7 +75,9 @@ registerRoute(
 );
 
 // Intercept individual restaurant fetches — update IDB as a side effect
-const restaurantByIDMatcher = /http:\/\/localhost:1337\/restaurants\/[0-9]+/;
+const restaurantByIDMatcher = ({ url }) =>
+  url.origin === SERVER_ORIGIN && /^\/restaurants\/[0-9]+$/.test(url.pathname);
+
 const restaurantByIDHandler = async ({ event }) => {
   try {
     const res = await fetch(event.request);
@@ -97,7 +100,10 @@ registerRoute(restaurantByIDMatcher, restaurantByIDHandler, "POST");
 
 // Intercept reviews list — update IDB as a side effect
 registerRoute(
-  /http:\/\/localhost:1337\/reviews\/\?restaurant_id=[0-9]+/,
+  ({ url }) =>
+    url.origin === SERVER_ORIGIN &&
+    url.pathname === "/reviews/" &&
+    url.searchParams.has("restaurant_id"),
   async ({ event }) => {
     try {
       const res = await fetch(event.request);


### PR DESCRIPTION
## Summary

- **#55** — Replace the `googleapis`/`gstatic` `StaleWhileRevalidate` route (caching nothing useful since the Leaflet migration) with a `tile.openstreetmap.org` route using a 500-entry / 30-day `ExpirationPlugin`, so map tiles are cached for offline use
- **#56** — Replace the hardcoded `const SERVER = "http://localhost:1337"` with `import.meta.env.API_SERVER || "http://localhost:1337"`, which Vite substitutes at build time from the `API_SERVER` env var; derive `SERVER_ORIGIN` from it and use function-based matchers for the restaurant-by-ID and reviews routes so they intercept the correct origin in production

## Test plan

- [ ] Build succeeds: `pnpm run build:ui` exits 0
- [ ] In `dist/sw.js`, grep for `tile.openstreetmap.org` — should be present; grep for `googleapis` — should be absent
- [ ] In `dist/sw.js`, grep for `localhost:1337` in the SERVER line — should be the fallback value only; the matchers should use `SERVER_ORIGIN` (function-based, not regex literals)
- [ ] With `API_SERVER=https://api.example.com pnpm run build:ui`, confirm `dist/sw.js` contains `https://api.example.com` as the SERVER value
- [ ] Offline smoke test (Chrome DevTools → Network tab → Offline): navigating to the home page still shows the restaurant list from IDB; restaurant detail map area shows cached tiles rather than blank

Closes #55, #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)