### PR TITLE
fix: review form validation and optimistic update on submission

### DIFF
--- a/src/js/CreateReviewModal.js
+++ b/src/js/CreateReviewModal.js
@@ -71,8 +71,33 @@ export default class CreateReviewModal {
   }
 
   submitForm() {
-    this.close();
     const postBody = this.getFormState();
+    const nameEl = document.querySelector("#name");
+    const ratingEl = document.querySelector("#rating");
+    const commentsEl = document.querySelector("#comments");
+
+    if (!postBody.name.trim()) {
+      nameEl.setCustomValidity("Please enter your name.");
+      nameEl.reportValidity();
+      return;
+    }
+    nameEl.setCustomValidity("");
+
+    if (!postBody.rating || postBody.rating < 1 || postBody.rating > 5) {
+      ratingEl.setCustomValidity("Please enter a rating between 1 and 5.");
+      ratingEl.reportValidity();
+      return;
+    }
+    ratingEl.setCustomValidity("");
+
+    if (!postBody.comments.trim()) {
+      commentsEl.setCustomValidity("Please enter a comment.");
+      commentsEl.reportValidity();
+      return;
+    }
+    commentsEl.setCustomValidity("");
+
+    this.close();
     console.log(`[App] Submitting post data`, postBody);
     this.onSubmit(postBody);
     this.clearFormState();

--- a/src/js/restaurant_info.js
+++ b/src/js/restaurant_info.js
@@ -42,8 +42,16 @@ document.addEventListener("DOMContentLoaded", async () => {
   const CRM = new CreateReviewModal({
     restaurantID: getParam("id"),
     onSubmit: async postBody => {
-      await postReview(postBody);
-      window.setTimeout(() => fetchReviewsFromURL(), 500);
+      const savedReview = await postReview(postBody);
+      if (savedReview) {
+        // Online: server confirmed the review — append it immediately without a round-trip
+        const reviews = [...(window.state.reviews || []), { ...savedReview, isDraft: false }];
+        fillReviewsHTML(reviews);
+        window.state.reviews = reviews;
+      } else {
+        // Offline (background sync): draft is now in IDB — re-fetch to show it immediately
+        fetchReviewsFromURL();
+      }
     }
   });
 

--- a/src/restaurant.html
+++ b/src/restaurant.html
@@ -58,11 +58,11 @@
     <form id="create-review-form" class="dialog" role="dialog" aria-labelledby="dialog-title">
       <h2 id="dialog-title">Create Review</h2>
       <label for="name">Name:</label>
-      <input type="text" id="name" name="name" autocomplete="name">
+      <input type="text" id="name" name="name" autocomplete="name" required>
       <label for="rating">Rating:</label>
-      <input type="number" name="rating" id="rating" min="1" max="5" step="1">
+      <input type="number" name="rating" id="rating" min="1" max="5" step="1" required>
       <label for="comments">Comments:</label>
-      <textarea cols="30" rows="10" id="comments" name="comments"></textarea>
+      <textarea cols="30" rows="10" id="comments" name="comments" required></textarea>
       <div id="button-row">
         <button id="close-create-review-modal-btn">
           <strong>Cancel</strong>


### PR DESCRIPTION
## Summary

- **#61** — Add client-side validation in `submitForm()`: checks that `name`, `rating` (1–5), and `comments` are all non-empty before closing the modal and submitting; uses `setCustomValidity` + `reportValidity` so errors surface through the browser's native UI. Also adds `required` attributes to the three inputs in `restaurant.html` so the browser's constraint validation fires before the `submit` event for keyboard/mouse submission paths.
- **#62** — Replace the hardcoded `window.setTimeout(() => fetchReviewsFromURL(), 500)` with an optimistic update: when online, the server response from `postReview` is appended directly to the current list (no round-trip, no race). When offline (background-sync path), `postReview` returns `undefined` and we call `fetchReviewsFromURL()` immediately to show the IDB draft — the SW `"message": "refresh"` event will trigger an authoritative re-fetch once synced.

## Test plan

- [ ] Build succeeds: `pnpm run build:ui` exits 0
- [ ] Submitting the review form with all fields empty shows a browser validation error (name field highlighted first)
- [ ] Submitting with a name but empty rating shows "Please enter a rating between 1 and 5."
- [ ] Submitting with rating=0 or rating=6 shows the rating validation error
- [ ] Submitting with name + valid rating but empty comments shows "Please enter a comment."
- [ ] Submitting a fully valid review closes the modal and the new review appears in the list immediately (no 500ms delay)
- [ ] After a valid submission the review list is not refetched from the server (no extra network request in DevTools)
- [ ] With network disabled (DevTools offline), submitting a review shows it as a DRAFT immediately in the list

Closes #61, #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)