### PR TITLE
chore: upgrade idb v2→v8 and fix sync-reviews data loss on schema bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "workbox-window": "^7.4.1"
   },
   "dependencies": {
-    "idb": "^2.1.1",
+    "idb": "^8.0.0",
     "leaflet": "^1.9.4",
     "lit-html": "^0.10.0",
     "responsively-lazy": "^2.0.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       idb:
-        specifier: ^2.1.1
-        version: 2.1.3
+        specifier: ^8.0.0
+        version: 8.0.3
       leaflet:
         specifier: ^1.9.4
         version: 1.9.4
@@ -1711,11 +1711,11 @@ packages:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
 
-  idb@2.1.3:
-    resolution: {integrity: sha512-1He6QAuavrD38HCiJasi4lEEK87Y22ldFuM+ZHkp433n4Fd5jXjWKutClYFp8w4mgx3zgrjnWxL8dpjMzcQ+WQ==}
-
   idb@7.1.1:
     resolution: {integrity: sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==}
+
+  idb@8.0.3:
+    resolution: {integrity: sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==}
 
   imagetools-core@9.1.0:
     resolution: {integrity: sha512-xQjs+2vrxLnAjCq+omuNkd5UQTld9/bP8+YT0LyYTlKfuSQtgUBvqhUwGugzSAh6sCdN+LnROMuLswn5hZ9Fhg==}
@@ -4750,9 +4750,9 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  idb@2.1.3: {}
-
   idb@7.1.1: {}
+
+  idb@8.0.3: {}
 
   imagetools-core@9.1.0: {}
 

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -1,23 +1,29 @@
-import * as idb from "idb";
+import { openDB } from "idb";
 
-const dbPromise = idb.open("restaurants-store", 7, db => {
-  if (!db.objectStoreNames.contains("restaurants")) {
-    db.createObjectStore("restaurants", { keyPath: "id" });
+const dbPromise = openDB("restaurants-store", 7, {
+  upgrade(db, oldVersion) {
+    if (!db.objectStoreNames.contains("restaurants")) {
+      db.createObjectStore("restaurants", { keyPath: "id" });
+    }
+    if (!db.objectStoreNames.contains("reviews")) {
+      db.createObjectStore("reviews", { keyPath: "id" });
+    }
+    // Only recreate sync-reviews when first introduced (oldVersion < 7).
+    // Deleting unconditionally on every upgrade would wipe queued offline drafts.
+    if (oldVersion < 7) {
+      if (db.objectStoreNames.contains("sync-reviews")) {
+        db.deleteObjectStore("sync-reviews");
+      }
+      db.createObjectStore("sync-reviews", { keyPath: "localId", autoIncrement: true });
+    }
   }
-  if (!db.objectStoreNames.contains("reviews")) {
-    db.createObjectStore("reviews", { keyPath: "id" });
-  }
-  if (db.objectStoreNames.contains("sync-reviews")) {
-    db.deleteObjectStore("sync-reviews");
-  }
-  db.createObjectStore("sync-reviews", { keyPath: "localId", autoIncrement: true });
 });
 
 export async function writeItem(storeName, item) {
   const db = await dbPromise;
   const tx = db.transaction(storeName, "readwrite");
   tx.objectStore(storeName).put(item);
-  return tx.complete;
+  return tx.done;
 }
 
 export async function getItems(storeName) {
@@ -35,14 +41,14 @@ export async function deleteItems(storeName) {
   const db = await dbPromise;
   const tx = db.transaction(storeName, "readwrite");
   tx.objectStore(storeName).clear();
-  return tx.complete;
+  return tx.done;
 }
 
 export async function deleteItem(storeName, id) {
   const db = await dbPromise;
   const tx = db.transaction(storeName, "readwrite");
   tx.objectStore(storeName).delete(id);
-  return tx.complete;
+  return tx.done;
 }
 
 // For some reason, the Sails backend returns inconsistent data


### PR DESCRIPTION
## Summary

- **#64** — Upgrade `idb` from `^2.1.1` (v2, EOL since 2018) to `^8.0.0` (current stable). Migrates the API:
  - `idb.open(name, version, callback)` → `openDB(name, version, { upgrade(db, oldVersion) { … } })`
  - `import * as idb from "idb"` → `import { openDB } from "idb"`
  - `tx.complete` → `tx.done` (three callsites: `writeItem`, `deleteItems`, `deleteItem`)
- **#63** — Guard the `sync-reviews` store delete+recreate behind `if (oldVersion < 7)` so it only runs when the store is first introduced. Previously it deleted the store unconditionally on every schema bump, silently discarding all queued offline reviews on every app update.

## Test plan

- [ ] Build succeeds: `pnpm run build:ui` exits 0
- [ ] `node_modules/idb/package.json` shows `"version": "8.x.x"`
- [ ] `src/js/utils.js` uses `openDB` (not `idb.open`), `tx.done` (not `tx.complete`), and the `upgrade` object form
- [ ] `sync-reviews` delete+recreate is inside `if (oldVersion < 7)` block
- [ ] Functional: opening the app in a browser with DevTools → Application → IndexedDB shows `restaurants-store` with all three object stores (`restaurants`, `reviews`, `sync-reviews`) intact after a page reload
- [ ] Data preservation: if reviews are queued in `sync-reviews` (offline drafts), bumping the DB version (by incrementing the version number in a test build) does NOT clear them

Closes #63, #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)