### PR TITLE
fix: eliminate circular import between Restaurant.js and main.js

### DIFF
--- a/src/js/RestaurantList/Restaurant/Restaurant.js
+++ b/src/js/RestaurantList/Restaurant/Restaurant.js
@@ -1,19 +1,18 @@
 import { html } from "lit-html";
 import { getImage } from "../../imageLoader";
 import { urlForRestaurant, updateRestaurant } from "../../dbhelper";
-import { updateRestaurants } from "../../main";
 import Heart from "./components/Heart";
 
-async function handleFavoriteClick(restaurant) {
+async function handleFavoriteClick(restaurant, onFavoriteToggle) {
   try {
     await updateRestaurant({ id: restaurant.id, is_favorite: !restaurant.is_favorite });
-    updateRestaurants();
+    onFavoriteToggle();
   } catch (e) {
     console.error(e);
   }
 }
 
-function Restaurant(restaurant) {
+function Restaurant(restaurant, onFavoriteToggle) {
   return html`
   <li>
   <div class="responsively-lazy" data-restaurantid=${restaurant.id} style="padding-bottom: 75%;">
@@ -39,7 +38,7 @@ function Restaurant(restaurant) {
       aria-pressed=${restaurant.is_favorite}
       style="padding-top: 10px; background-color: white; border: none; color: white;"
       class="favorite-button"
-      @click=${() => handleFavoriteClick(restaurant)}
+      @click=${() => handleFavoriteClick(restaurant, onFavoriteToggle)}
     >
       ${Heart(40, 40, restaurant.is_favorite)}
     </button>

--- a/src/js/RestaurantList/RestaurantList.js
+++ b/src/js/RestaurantList/RestaurantList.js
@@ -2,6 +2,6 @@ import { html } from "lit-html";
 
 import Restaurant from "./Restaurant";
 
-export default function RestaurantList(restaurants) {
-  return html`${restaurants.map(restaurant => Restaurant(restaurant))}`;
+export default function RestaurantList(restaurants, onFavoriteToggle) {
+  return html`${restaurants.map(restaurant => Restaurant(restaurant, onFavoriteToggle))}`;
 }

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -81,7 +81,7 @@ export const updateRestaurants = async () => {
   try {
     const filteredRestaurants = await fetchRestaurantByCuisineAndNeighborhood(cuisine, neighborhood);
     const restaurantListMountPoint = document.getElementById("restaurants-list");
-    render(RestaurantList(filteredRestaurants), restaurantListMountPoint);
+    render(RestaurantList(filteredRestaurants, updateRestaurants), restaurantListMountPoint);
     if (window.state.map) {
       window.state.markers.forEach(m => m.remove());
       window.state.markers = [];


### PR DESCRIPTION
## Summary

Closes **#59**.

`Restaurant.js` imported `updateRestaurants` directly from `main.js`, creating the cycle:

```
main.js → RestaurantList/index.js → RestaurantList.js → Restaurant/index.js → Restaurant.js → main.js
```

This makes `Restaurant` impossible to use or test independently of the top-level entry point.

**Fix:** thread `onFavoriteToggle` as a parameter through the call chain:
- `main.js` passes `updateRestaurants` when calling `RestaurantList(filteredRestaurants, updateRestaurants)`
- `RestaurantList` accepts `onFavoriteToggle` and forwards it to each `Restaurant(restaurant, onFavoriteToggle)`
- `Restaurant` receives the callback and calls it on favorite-click — no import from `main.js`

## Test plan

- [ ] Build succeeds: `pnpm run build:ui` exits 0
- [ ] `src/js/RestaurantList/Restaurant/Restaurant.js` has no `import` from `../../main`
- [ ] Toggling a restaurant's favorite heart on the home page still updates the UI (re-renders the list with the new favorite state)
- [ ] The favorite state is persisted (network request to PUT `/restaurants/:id` is made on toggle)

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)