### PR TITLE
chore: upgrade lit-html from v0.10.2 (pre-1.0 alpha) to v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "idb": "^2.1.1",
     "leaflet": "^1.9.4",
-    "lit-html": "^0.10.0",
+    "lit-html": "^3.0.0",
     "responsively-lazy": "^2.0.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^1.9.4
         version: 1.9.4
       lit-html:
-        specifier: ^0.10.0
-        version: 0.10.2
+        specifier: ^3.0.0
+        version: 3.3.3
       responsively-lazy:
         specifier: ^2.0.2
         version: 2.0.2
@@ -1986,8 +1986,8 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
-  lit-html@0.10.2:
-    resolution: {integrity: sha512-ue0pIX3Fj5gUsNSozdRQIb1MAgNqFQsHgvHE/FU34xyu9NN/af3EISr7Bb+vP9YeLXIA4vLLOoYp2Z22dVYhww==}
+  lit-html@3.3.3:
+    resolution: {integrity: sha512-el8M6jK2o3RXBnrSHX3ZKrsN8zEV63pSExTO1wYJz7QndGYZ8353e2a5PPX+qHe2aGayfnchQmkAojaWAREOIA==}
 
   load-json-file@4.0.0:
     resolution: {integrity: sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==}
@@ -4987,7 +4987,9 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
-  lit-html@0.10.2: {}
+  lit-html@3.3.3:
+    dependencies:
+      '@types/trusted-types': 2.0.7
 
   load-json-file@4.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

Closes **#65**.

Upgrades `lit-html` from `^0.10.0` (resolving to v0.10.2, a 2018 pre-1.0 alpha) to `^3.0.0` (resolving to v3.3.3, current stable). The library has had no security patches for 6+ years at the old version.

The public API used by this project is unchanged in v3:
- `import { html, render } from "lit-html"` — same import path
- `html\`...\`` tagged template literals — same syntax
- `@click=${handler}` event binding — same syntax
- `render(template, container)` — same signature

Build output confirms 81 modules transformed with no errors.

## Test plan

- [ ] Build succeeds: `pnpm run build:ui` exits 0
- [ ] `node_modules/lit-html/package.json` shows `"version": "3.x.x"`
- [ ] Home page renders the restaurant list (lit-html `render` works)
- [ ] Clicking the heart/favorite button on a restaurant card fires the click handler (lit-html `@click` event binding works)
- [ ] Restaurant detail page renders the reviews list (`render` into `#reviews-list` works)
- [ ] "No Reviews yet!" placeholder renders when there are no reviews

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)