### PR TITLE
Fix Enter key closing review modal instead of submitting

### DIFF
--- a/src/js/CreateReviewModal.js
+++ b/src/js/CreateReviewModal.js
@@ -143,7 +143,8 @@ export default class CreateReviewModal {
         this.close();
         break;
       case KEY_ENTER:
-        this.close();
+        e.preventDefault();
+        this.submitForm();
         break;
       default:
         break;


### PR DESCRIPTION
## Summary
In the review modal keyboard handler, the Enter key case was calling `this.close()` instead of `this.submitForm()`. This meant pressing Enter anywhere inside the modal would dismiss it without submitting the review. The fix intercepts Enter and calls `submitForm()` (with `e.preventDefault()` to avoid double-firing on submit buttons).

Closes #73