### PR TITLE
Fix dead-code offline error message in service worker

### DIFF
--- a/src/sw.js
+++ b/src/sw.js
@@ -182,7 +182,7 @@ function syncNewReviews() {
         })
         .catch(err => {
           const humanFriendlyErrorMessage =
-            err == "TypeError: Failed to fetch"
+            err instanceof TypeError && err.message === "Failed to fetch"
               ? `[SW] Unable to sync reviews with server. This is probably because you are offline`
               : `[SW] Unable to sync reviews with server due to an unknown error. Please contact the developer with the following error message: ${err}`;
           if (!notifiedClient) {


### PR DESCRIPTION
## Summary
The service worker's `syncNewReviews` catch block compared the caught error using `err == "TypeError: Failed to fetch"`. Since `fetch` rejects with a `TypeError` object (not a string), this string comparison always evaluated to `false`, making the offline-friendly error message dead code — the generic unknown-error message was shown instead.

Fixed by checking `err instanceof TypeError && err.message === "Failed to fetch"`, which correctly identifies the network-unavailable case.

Closes #74