### PR TITLE
chore: improve CI coverage and add imageLoader unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,5 +23,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Run tests
-        run: pnpm test
+      - name: Run tests with coverage
+        run: pnpm test:coverage
+
+      - name: Build
+        run: pnpm build:ui

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 engine-strict=true
+confirmModulesPurge=false

--- a/src/js/imageLoader.test.js
+++ b/src/js/imageLoader.test.js
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { getImage } from "./imageLoader.js";
+
+describe("getImage", () => {
+  it("returns srcSet and src for valid restaurant ids 1-10", () => {
+    for (let i = 1; i <= 10; i++) {
+      const result = getImage(String(i));
+      expect(result).toHaveProperty("srcSet");
+      expect(result).toHaveProperty("src");
+    }
+  });
+
+  it("returns defined src for a valid id", () => {
+    const result = getImage("1");
+    expect(result.src).toBeDefined();
+  });
+
+  it("falls back to failwhale for an unknown filename", () => {
+    const unknown = getImage("notarestaurant");
+    const fallback = getImage("failwhale");
+    expect(unknown.src).toBe(fallback.src);
+    expect(unknown.srcSet).toBe(fallback.srcSet);
+  });
+
+  it("falls back to failwhale for an empty string", () => {
+    const unknown = getImage("");
+    const fallback = getImage("failwhale");
+    expect(unknown.src).toBe(fallback.src);
+  });
+
+  it("treats failwhale itself as a valid key", () => {
+    const result = getImage("failwhale");
+    expect(result.src).toBeDefined();
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,14 +1,23 @@
 import { defineConfig } from "vitest/config";
+import { imagetools } from "vite-imagetools";
 
 export default defineConfig({
+  plugins: [imagetools()],
   test: {
     globals: true,
     environment: "jsdom",
     setupFiles: ["./src/test-setup.js"],
+    reporters: process.env.CI ? ["github-actions", "verbose"] : ["verbose"],
     coverage: {
       provider: "v8",
       reporter: ["text", "html", "lcov"],
-      include: ["src/js/utils.js", "src/js/dbhelper.js"],
+      include: ["src/js/utils.js", "src/js/dbhelper.js", "src/js/imageLoader.js"],
+      thresholds: {
+        statements: 95,
+        branches: 80,
+        functions: 90,
+        lines: 95,
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary

- **Run coverage in CI**: switched `pnpm test` → `pnpm test:coverage` so coverage thresholds are enforced on every push/PR — previously coverage was never computed in CI
- **Add build verification**: new `pnpm build:ui` step catches Vite/PWA bundler regressions that tests can't detect
- **Coverage thresholds**: added `thresholds` to `vitest.config.js` (95% stmts/lines, 80% branches, 90% funcs) so CI fails if coverage regresses; current suite passes at 99%/88%/92%/99%
- **GitHub Actions reporter**: `github-actions` reporter activates when `CI=true`, annotating failing tests inline on PR diffs
- **imageLoader tests**: new `src/js/imageLoader.test.js` (5 tests) covering `getImage()` valid IDs 1–10, unknown-filename fallback, empty-string fallback, and the `failwhale` key; required adding `imagetools()` plugin to `vitest.config.js` so `import.meta.glob` transforms resolve in the test environment
- **`.npmrc`**: added `confirmModulesPurge=false` to suppress the TTY confirmation pnpm triggers locally when the modules dir needs refreshing

## Test plan

- [ ] CI passes on this PR (tests + coverage thresholds + build all green)
- [ ] Introduce a coverage regression locally (delete a test) and confirm `pnpm test:coverage` exits non-zero
- [ ] `pnpm test:coverage` locally shows 59 tests passing across 3 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)