### PR TITLE
fix: use textContent for option labels in main.js to prevent XSS

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -43,7 +43,7 @@ async function fetchAndFillNeighborhoods() {
     const select = document.getElementById("neighborhoods-select");
     neighborhoods.forEach(neighborhood => {
       const option = document.createElement("option");
-      option.innerHTML = neighborhood;
+      option.textContent = neighborhood;
       option.value = neighborhood;
       select.append(option);
     });
@@ -58,7 +58,7 @@ async function fetchAndFillCuisines() {
     const select = document.getElementById("cuisines-select");
     cuisines.forEach(cuisine => {
       const option = document.createElement("option");
-      option.innerHTML = cuisine;
+      option.textContent = cuisine;
       option.value = cuisine;
       select.append(option);
     });


### PR DESCRIPTION
## Summary

Fixes the XSS injection points reported in #79. In `src/js/main.js`, neighborhood and cuisine strings fetched from the API were inserted into `<option>` elements via `innerHTML`, so any HTML in those values would be parsed and executed in every visitor's browser. Both assignments now use `textContent`.

```diff
-      option.innerHTML = neighborhood;
+      option.textContent = neighborhood;
...
-      option.innerHTML = cuisine;
+      option.textContent = cuisine;
```

The `value` attribute (used for filtering) is unchanged.

## Verification

Ran the app (Sails API + Vite dev server) and tested at the dropdown surface:

- **No regression** — neighborhood (`Manhattan/Brooklyn/Queens`) and cuisine (`Asian/Pizza/American/Mexican`) dropdowns populate correctly, and each option's `value` still matches its text so filtering works.
- **Injection closed** — reproduced the app's option-creation code against the real `<select>` with the payload `<img src=x onerror=...>`:
  - With `innerHTML` (old): an `<img>` element was created and its `onerror` **fired** — confirming the vulnerability was real.
  - With `textContent` (this fix): zero child elements, no `<img>`, the payload renders as inert literal text.

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)