### PR TITLE
feat: migrate server-side code from CommonJS to ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "--- #### _Three Stage Course Material Project - Restaurant Reviews_",
   "private": true,
+  "type": "module",
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest",

--- a/serve.js
+++ b/serve.js
@@ -17,8 +17,11 @@ app.use(
   )
 );
 
+// Use the `root` option rather than passing an absolute path: Express 5's
+// `send` rejects Windows backslash absolute paths (from `path.resolve`) with a
+// spurious 404. The `root` form is normalized cross-platform.
 app.get("/restaurant.html", (req, res) =>
-  res.sendFile(path.resolve(__dirname, "dist", "restaurant.html"))
+  res.sendFile("restaurant.html", { root: path.resolve(__dirname, "dist") })
 );
 // Serve static assets, and do not automatically direct to the index
 app.use(express.static(path.resolve(__dirname, "dist")));

--- a/serve.js
+++ b/serve.js
@@ -1,7 +1,10 @@
-const express = require("express");
-const morgan = require("morgan");
-const path = require("path");
-const compression = require("compression");
+import express from "express";
+import morgan from "morgan";
+import path from "path";
+import compression from "compression";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const app = express();
 
 // Setup Gzip compression of response bodies

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,6 +2,9 @@ import { defineConfig } from "vite";
 import { VitePWA } from "vite-plugin-pwa";
 import { imagetools } from "vite-imagetools";
 import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // Multi-page PWA. `root` is `src/`, so HTML entry points, the service-worker
 // source and the `public/` static dir all live under `src/`. The build emits to


### PR DESCRIPTION
## Summary

Finishes the CommonJS → ESM migration (issue #91) for the **root-level** Node code, plus a small correctness fix to `serve.js` surfaced while testing. After the Sails server was replaced by an Express + `node:sqlite` backend (#98, already ESM), the only server-side CJS left was the root.

Two commits:

1. **ESM migration** (3 files):
   - `package.json` — add `"type": "module"` so root `.js` files are ESM
   - `serve.js` — `require()` → `import`, add a `fileURLToPath`-based `__dirname` shim
   - `vite.config.js` — add the same `__dirname` shim (it references `__dirname`, no longer a global once the package is ESM)

2. **serve.js sendFile fix:** `res.sendFile(path.resolve(__dirname, "dist", "restaurant.html"))` passed a Windows backslash absolute path, which Express 5's `send` rejects with a spurious 404 even though the file exists (Linux was unaffected). Switched to the `root`-option form, which `send` normalizes cross-platform.

Rebased onto current `master`; the original restaurant-server changes (which targeted the old Sails files) are obsolete and were dropped during the rebase.

## Test plan

Verified locally on Node 24.16 (Windows) + green in CI (Linux):

- [x] `pnpm test` — 59/59 pass under `"type": "module"`
- [x] `pnpm build:ui` — green; `vite.config.js` loads as ESM with the `__dirname` shim
- [x] `node serve.js` boots as an ES module (no `__dirname` ReferenceError) and serves the built `dist/` on port 7000
- [x] `/`, `/healthcheck`, **and `/restaurant.html`** all return 200 (the last was a 404 before the sendFile fix; now returns the `Restaurant Info` page)

Closes #91