### PR TITLE
fix: suppress inlineDynamicImports deprecation warning in vite-plugin-pwa

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -41,7 +41,11 @@ export default defineConfig({
         // Precache the app shell only (both HTML pages, JS, CSS) plus the web
         // manifest. Restaurant photos are runtime-cached (StaleWhileRevalidate in
         // sw.js), matching the previous webpack InjectManifest scope.
-        globPatterns: ["**/*.{js,css,html}", "manifest.json"]
+        globPatterns: ["**/*.{js,css,html}", "manifest.json"],
+        // vite-plugin-pwa's ES-format SW build hardcodes inlineDynamicImports:true
+        // in rollup output options, which Vite 8/Rolldown has deprecated. The IIFE
+        // format path has no such option and produces identical sw.js output.
+        rollupFormat: "iife"
       },
       // No service worker in dev: the precaching SW serves stale navigations,
       // masking source edits and interfering with HMR. It's exercised in the


### PR DESCRIPTION
## Summary

- `vite-plugin-pwa` 1.3.0 hardcodes `output.inlineDynamicImports: true` in its ES-format service-worker Vite build, which Vite 8/Rolldown has deprecated in favour of `build.codeSplitting: false`
- There is no user-config escape hatch into that code path — `codeSplitting` passed through `injectManifest` goes to workbox, not to the internal SW Vite build
- The plugin's IIFE format path skips the deprecated option entirely; it emits `sw.js` directly (the ES path outputs `sw.mjs` and renames it to `sw.js` anyway), so the artefact is identical
- Since `src/sw.js` uses only static imports that Rolldown bundles inline, switching output format has no runtime impact

## Test plan

- [ ] `pnpm build:ui` completes with no `WARN inlineDynamicImports` line
- [ ] Build output includes `dist/sw.js` with precache entries
- [ ] `node serve.js` serves the app on port 7000 without errors

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)