### PR TITLE
dep: remove responsively-lazy, replace with native loading=lazy + srcset

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
   "dependencies": {
     "idb": "^8.0.0",
     "leaflet": "^1.9.4",
-    "lit-html": "^3.0.0",
-    "responsively-lazy": "^3.2.1"
+    "lit-html": "^3.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       lit-html:
         specifier: ^3.0.0
         version: 3.3.3
-      responsively-lazy:
-        specifier: ^3.2.1
-        version: 3.2.1
     devDependencies:
       '@vitest/coverage-v8':
         specifier: ^4.1.8
@@ -2275,9 +2272,6 @@ packages:
     resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
     engines: {node: '>= 0.4'}
     hasBin: true
-
-  responsively-lazy@3.2.1:
-    resolution: {integrity: sha512-REmwjqEX7qr4u8yXHH3TLYLC2ofzs+z7xoOWtTHL1TRlz9qRi5oe5JHHgoPFW4zclWyq8wOzv3gyb/629xtRZg==}
 
   rolldown@1.0.3:
     resolution: {integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==}
@@ -5106,8 +5100,6 @@ snapshots:
       is-core-module: 2.16.2
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
-
-  responsively-lazy@3.2.1: {}
 
   rolldown@1.0.3:
     dependencies:

--- a/src/js/RestaurantList/Restaurant/Restaurant.js
+++ b/src/js/RestaurantList/Restaurant/Restaurant.js
@@ -19,9 +19,10 @@ function Restaurant(restaurant, onFavoriteToggle) {
     alt="Image of ${restaurant.name}"
     class="restaurant-img"
     style="aspect-ratio: 4 / 3;"
-    data-responsively-lazy=${getImage(restaurant.photograph).srcSet}
-    srcset="data:image/gif;base64,R0lGODlhAQABAIAAAP///////yH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
+    srcset=${getImage(restaurant.photograph).srcSet}
     src=${getImage(restaurant.photograph).src}
+    loading="lazy"
+    decoding="async"
   />
   <h1>${restaurant.name}</h1>
   <p>${restaurant.neighborhood}</p>

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,4 +1,3 @@
-import "responsively-lazy/responsively-lazy.js";
 import {
   fetchNeighborhoods,
   fetchCuisines,


### PR DESCRIPTION
## Summary

- Removes the `responsively-lazy` npm dependency entirely
- Replaces the `data-responsively-lazy` / base64 placeholder `srcset` pattern with a real `srcset` attribute directly on `<img>`
- Adds `loading="lazy"` and `decoding="async"` for native browser lazy-loading
- Removes the `import "responsively-lazy/responsively-lazy.js"` line from `main.js`

## Why

Native `loading="lazy"` + `srcset` is supported in all modern browsers (Chrome 77+, Firefox 75+, Safari 15.4+, Edge 79+). The `responsively-lazy` library intercepts scroll events to swap a placeholder `srcset` with the real one — that mechanism is now fully superseded by the browser platform, making the dependency dead weight.

Closes #100

## Test plan

- [x] `npm run build:ui` passes cleanly with no references to `responsively-lazy`
- [x] Dev server renders all 10 restaurants with images present in the accessibility tree
- [x] Neighborhood and cuisine filters still populate correctly from the API

🤖 Generated with [Claude Code](https://claude.com/claude-code)