### PR TITLE
refactor: tighten TypeScript types

### DIFF
--- a/restaurant-server/routes.ts
+++ b/restaurant-server/routes.ts
@@ -29,6 +29,17 @@ import type {
 
 const now = (): string => new Date().toISOString();
 
+// node:sqlite returns rows as `Record<string, SQLOutputValue>`. These two helpers
+// centralize the unavoidable cast to our typed row shapes in a single place, so
+// the handlers below stay free of inline `as` assertions.
+function one<T>(db: DatabaseSync, sql: string, ...params: SQLInputValue[]): T | undefined {
+  return db.prepare(sql).get(...params) as unknown as T | undefined;
+}
+
+function all<T>(db: DatabaseSync, sql: string, ...params: SQLInputValue[]): T[] {
+  return db.prepare(sql).all(...params) as unknown as T[];
+}
+
 // Row → API object. SQLite stores latlng/operating_hours as JSON text and
 // is_favorite as 0/1, so unpack those back into the shapes the client expects.
 function toRestaurant(row: RestaurantRow): Restaurant {
@@ -90,7 +101,7 @@ function applyUpdate<TRow, TOut>(
   body: Record<string, unknown>,
   mapRow: (row: TRow) => TOut
 ): TOut | null {
-  const existing = db.prepare(`SELECT * FROM ${table} WHERE id = ?`).get(id);
+  const existing = one<TRow>(db, `SELECT * FROM ${table} WHERE id = ?`, id);
   if (!existing) return null;
 
   const sets: string[] = [];
@@ -106,8 +117,8 @@ function applyUpdate<TRow, TOut>(
   values.push(id);
 
   db.prepare(`UPDATE ${table} SET ${sets.join(", ")} WHERE id = ?`).run(...values);
-  const row = db.prepare(`SELECT * FROM ${table} WHERE id = ?`).get(id) as TRow;
-  return mapRow(row);
+  // The row necessarily exists — `existing` was found above and the UPDATE keeps it.
+  return mapRow(one<TRow>(db, `SELECT * FROM ${table} WHERE id = ?`, id)!);
 }
 
 export function createApiRouter(db: DatabaseSync): Router {
@@ -116,16 +127,16 @@ export function createApiRouter(db: DatabaseSync): Router {
   // ----- Restaurants -----
 
   router.get("/restaurants", (_req, res) => {
-    const rows = db
-      .prepare("SELECT * FROM restaurants ORDER BY id")
-      .all() as unknown as RestaurantRow[];
+    const rows = all<RestaurantRow>(db, "SELECT * FROM restaurants ORDER BY id");
     res.json(rows.map(toRestaurant));
   });
 
   router.get("/restaurants/:id", (req, res) => {
-    const row = db
-      .prepare("SELECT * FROM restaurants WHERE id = ?")
-      .get(Number(req.params.id)) as RestaurantRow | undefined;
+    const row = one<RestaurantRow>(
+      db,
+      "SELECT * FROM restaurants WHERE id = ?",
+      Number(req.params.id)
+    );
     if (!row) return res.status(404).json({ error: "Restaurant not found" });
     res.json(toRestaurant(row));
   });
@@ -153,9 +164,11 @@ export function createApiRouter(db: DatabaseSync): Router {
         ts,
         ts
       );
-    const created = db
-      .prepare("SELECT * FROM restaurants WHERE id = ?")
-      .get(Number(info.lastInsertRowid)) as unknown as RestaurantRow;
+    const created = one<RestaurantRow>(
+      db,
+      "SELECT * FROM restaurants WHERE id = ?",
+      Number(info.lastInsertRowid)
+    )!;
     res.status(201).json(toRestaurant(created));
   });
 
@@ -174,9 +187,7 @@ export function createApiRouter(db: DatabaseSync): Router {
 
   router.delete("/restaurants/:id", (req, res) => {
     const id = Number(req.params.id);
-    const row = db
-      .prepare("SELECT * FROM restaurants WHERE id = ?")
-      .get(id) as RestaurantRow | undefined;
+    const row = one<RestaurantRow>(db, "SELECT * FROM restaurants WHERE id = ?", id);
     if (!row) return res.status(404).json({ error: "Restaurant not found" });
     db.prepare("DELETE FROM restaurants WHERE id = ?").run(id);
     res.json(toRestaurant(row));
@@ -186,20 +197,23 @@ export function createApiRouter(db: DatabaseSync): Router {
 
   router.get("/reviews", (req, res) => {
     const { restaurant_id } = req.query;
-    const rows = (
+    const rows =
       restaurant_id !== undefined
-        ? db
-            .prepare("SELECT * FROM reviews WHERE restaurant_id = ? ORDER BY id")
-            .all(Number(restaurant_id))
-        : db.prepare("SELECT * FROM reviews ORDER BY id").all()
-    ) as unknown as ReviewRow[];
+        ? all<ReviewRow>(
+            db,
+            "SELECT * FROM reviews WHERE restaurant_id = ? ORDER BY id",
+            Number(restaurant_id)
+          )
+        : all<ReviewRow>(db, "SELECT * FROM reviews ORDER BY id");
     res.json(rows.map(toReview));
   });
 
   router.get("/reviews/:id", (req, res) => {
-    const row = db
-      .prepare("SELECT * FROM reviews WHERE id = ?")
-      .get(Number(req.params.id)) as ReviewRow | undefined;
+    const row = one<ReviewRow>(
+      db,
+      "SELECT * FROM reviews WHERE id = ?",
+      Number(req.params.id)
+    );
     if (!row) return res.status(404).json({ error: "Review not found" });
     res.json(toReview(row));
   });
@@ -227,9 +241,11 @@ export function createApiRouter(db: DatabaseSync): Router {
         ts,
         ts
       );
-    const created = db
-      .prepare("SELECT * FROM reviews WHERE id = ?")
-      .get(Number(info.lastInsertRowid)) as unknown as ReviewRow;
+    const created = one<ReviewRow>(
+      db,
+      "SELECT * FROM reviews WHERE id = ?",
+      Number(info.lastInsertRowid)
+    )!;
     res.status(201).json(toReview(created));
   });
 
@@ -248,9 +264,7 @@ export function createApiRouter(db: DatabaseSync): Router {
 
   router.delete("/reviews/:id", (req, res) => {
     const id = Number(req.params.id);
-    const row = db
-      .prepare("SELECT * FROM reviews WHERE id = ?")
-      .get(id) as ReviewRow | undefined;
+    const row = one<ReviewRow>(db, "SELECT * FROM reviews WHERE id = ?", id);
     if (!row) return res.status(404).json({ error: "Review not found" });
     db.prepare("DELETE FROM reviews WHERE id = ?").run(id);
     res.json(toReview(row));

--- a/restaurant-server/tsconfig.json
+++ b/restaurant-server/tsconfig.json
@@ -1,18 +1,12 @@
 {
+  "extends": "../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2023",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "lib": ["ES2023"],
     "types": ["node"],
-    "strict": true,
-    "noEmit": true,
     "allowImportingTsExtensions": true,
-    "esModuleInterop": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "esModuleInterop": true
   },
   "include": ["**/*.ts"]
 }

--- a/src/js/CreateReviewModal.ts
+++ b/src/js/CreateReviewModal.ts
@@ -12,8 +12,8 @@ export default class CreateReviewModal {
   form: HTMLFormElement;
   closeBtn: HTMLElement;
   internalFocusableEls: NodeListOf<HTMLElement>;
-  firstFocusableEl: HTMLElement;
-  lastFocusableEl: HTMLElement;
+  firstFocusableEl: HTMLElement | undefined;
+  lastFocusableEl: HTMLElement | undefined;
   focusedElBeforeOpen: HTMLElement | null = null;
 
   constructor({ restaurantID, onSubmit }: CreateReviewModalOptions) {
@@ -70,7 +70,7 @@ export default class CreateReviewModal {
     window.setTimeout(() => {
       this.focusedElBeforeOpen = document.activeElement as HTMLElement | null;
       this.modal.style.transform = "translateY(0)";
-      this.firstFocusableEl.focus();
+      this.firstFocusableEl?.focus();
     }, 50);
   }
 
@@ -134,13 +134,13 @@ export default class CreateReviewModal {
     const handleBackwardTab = () => {
       if (document.activeElement === this.firstFocusableEl) {
         e.preventDefault();
-        this.lastFocusableEl.focus();
+        this.lastFocusableEl?.focus();
       }
     };
     const handleForwardTab = () => {
       if (document.activeElement === this.lastFocusableEl) {
         e.preventDefault();
-        this.firstFocusableEl.focus();
+        this.firstFocusableEl?.focus();
       }
     };
 

--- a/src/js/dbhelper.test.ts
+++ b/src/js/dbhelper.test.ts
@@ -67,19 +67,19 @@ describe("fetchRestaurants", () => {
   });
 
   it("falls back to IDB when fetch throws (offline)", async () => {
-    await writeItem("restaurants", RESTAURANTS[0]);
-    await writeItem("restaurants", RESTAURANTS[1]);
+    await writeItem("restaurants", RESTAURANTS[0]!);
+    await writeItem("restaurants", RESTAURANTS[1]!);
     vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("Failed to fetch")));
     const result = await fetchRestaurants();
     expect(result).toHaveLength(2);
   });
 
   it("falls back to IDB when response is not ok", async () => {
-    await writeItem("restaurants", RESTAURANTS[2]);
+    await writeItem("restaurants", RESTAURANTS[2]!);
     vi.stubGlobal("fetch", makeFetch(null, { ok: false, status: 503 }));
     const result = await fetchRestaurants();
     expect(result).toHaveLength(1);
-    expect(result[0].id).toBe(3);
+    expect(result[0]?.id).toBe(3);
   });
 
   it("writes successful network results into IDB", async () => {
@@ -110,14 +110,14 @@ describe("fetchRestaurantById", () => {
   });
 
   it("falls back to IDB on network error", async () => {
-    await writeItem("restaurants", RESTAURANTS[2]);
+    await writeItem("restaurants", RESTAURANTS[2]!);
     vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("Failed to fetch")));
     const result = await fetchRestaurantById(3);
     expect(result?.id).toBe(3);
   });
 
   it("falls back to IDB when response is not ok", async () => {
-    await writeItem("restaurants", RESTAURANTS[1]);
+    await writeItem("restaurants", RESTAURANTS[1]!);
     vi.stubGlobal("fetch", makeFetch(null, { ok: false, status: 404 }));
     const result = await fetchRestaurantById(2);
     expect(result?.id).toBe(2);
@@ -140,19 +140,19 @@ describe("fetchRestaurantByCuisineAndNeighborhood", () => {
   it("filters to a single cuisine type", async () => {
     const result = await fetchRestaurantByCuisineAndNeighborhood("Chinese", "all");
     expect(result).toHaveLength(1);
-    expect(result[0].cuisine_type).toBe("Chinese");
+    expect(result[0]?.cuisine_type).toBe("Chinese");
   });
 
   it("filters to a single neighborhood", async () => {
     const result = await fetchRestaurantByCuisineAndNeighborhood("all", "Queens");
     expect(result).toHaveLength(1);
-    expect(result[0].neighborhood).toBe("Queens");
+    expect(result[0]?.neighborhood).toBe("Queens");
   });
 
   it("filters by both cuisine and neighborhood", async () => {
     const result = await fetchRestaurantByCuisineAndNeighborhood("Pizza", "Manhattan");
     expect(result).toHaveLength(1);
-    expect(result[0].name).toBe("Emily");
+    expect(result[0]?.name).toBe("Emily");
   });
 
   it("returns empty array when no restaurant matches", async () => {
@@ -169,7 +169,7 @@ describe("fetchRestaurantByCuisine", () => {
     vi.stubGlobal("fetch", makeFetch(RESTAURANTS));
     const result = await fetchRestaurantByCuisine("Korean");
     expect(result).toHaveLength(1);
-    expect(result[0].id).toBe(3);
+    expect(result[0]?.id).toBe(3);
   });
 });
 
@@ -391,7 +391,15 @@ describe("postReview", () => {
 
 describe("fetchReviewsForRestaurant", () => {
   const serverReviews = [
-    { id: 100, restaurant_id: 1, name: "Server User", rating: 5, comments: "Posted" },
+    {
+      id: 100,
+      restaurant_id: 1,
+      name: "Server User",
+      rating: 5,
+      comments: "Posted",
+      createdAt: "2024-01-01T00:00:00.000Z",
+      updatedAt: "2024-01-01T00:00:00.000Z",
+    },
   ];
   const draft = { localId: 1, restaurant_id: 1, name: "Draft User", rating: 3, comments: "Pending" };
 
@@ -416,7 +424,7 @@ describe("fetchReviewsForRestaurant", () => {
   });
 
   it("falls back to cached IDB reviews when offline", async () => {
-    await writeItem("reviews", { ...serverReviews[0], isDraft: false });
+    await writeItem("reviews", serverReviews[0]!);
     vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("Failed to fetch")));
     const result = await fetchReviewsForRestaurant(1);
     expect(result.some(r => r.id === 100)).toBe(true);
@@ -429,7 +437,7 @@ describe("fetchReviewsForRestaurant", () => {
   });
 
   it("falls back to cached IDB reviews when response is not ok", async () => {
-    await writeItem("reviews", { ...serverReviews[0], isDraft: false });
+    await writeItem("reviews", serverReviews[0]!);
     vi.stubGlobal("fetch", makeFetch(null, { ok: false, status: 503 }));
     const result = await fetchReviewsForRestaurant(1);
     expect(result.some(r => r.id === 100)).toBe(true);

--- a/src/js/dbhelper.ts
+++ b/src/js/dbhelper.ts
@@ -19,7 +19,7 @@ export async function fetchRestaurants(): Promise<Restaurant[]> {
   } catch {
     // Network unavailable — fall through to IDB
   }
-  return getItems<Restaurant>("restaurants");
+  return getItems("restaurants");
 }
 
 export async function fetchRestaurantById(
@@ -36,7 +36,7 @@ export async function fetchRestaurantById(
   } catch {
     // Network unavailable — fall through to IDB
   }
-  return getItem<Restaurant>("restaurants", id);
+  return getItem("restaurants", id);
 }
 
 export async function updateRestaurant(body: Partial<Restaurant>): Promise<Restaurant> {
@@ -128,7 +128,7 @@ export async function fetchReviewsForRestaurant(
   restaurantID: number | string
 ): Promise<DisplayReview[]> {
   const id = Number(restaurantID);
-  const draftReviews: DisplayReview[] = await getItems<ReviewDraft>("sync-reviews").then(items =>
+  const draftReviews: DisplayReview[] = await getItems("sync-reviews").then(items =>
     items
       .filter(r => Number(r.restaurant_id) === id)
       .map(r => ({ ...r, isDraft: true }))
@@ -145,7 +145,7 @@ export async function fetchReviewsForRestaurant(
     // Network unavailable — fall through to IDB
   }
 
-  const cachedReviews: DisplayReview[] = await getItems<Review>("reviews").then(items =>
+  const cachedReviews: DisplayReview[] = await getItems("reviews").then(items =>
     items
       .filter(r => r.restaurant_id === id)
       .map(r => ({ ...r, isDraft: false }))

--- a/src/js/imageLoader.ts
+++ b/src/js/imageLoader.ts
@@ -24,5 +24,7 @@ export interface RestaurantImage {
 export function getImage(fileName: string | null | undefined): RestaurantImage {
   const name = fileName && VALID.has(fileName) ? fileName : FALLBACK;
   const key = `../img/${name}.jpg`;
-  return { srcSet: srcsets[key], src: fallbacks[key] };
+  // `name` is always a VALID id (or the bundled FALLBACK), so both globs have an
+  // entry for `key` — assert past the index signature's `| undefined`.
+  return { srcSet: srcsets[key]!, src: fallbacks[key]! };
 }

--- a/src/js/restaurant_info.ts
+++ b/src/js/restaurant_info.ts
@@ -63,7 +63,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   if ("serviceWorker" in navigator) {
     navigator.serviceWorker.addEventListener("message", event => {
-      event.ports[0].postMessage("ACK");
+      event.ports[0]?.postMessage("ACK");
       if (event.data === "refresh") {
         fetchReviewsFromURL();
       }
@@ -146,7 +146,7 @@ function fillRestaurantHoursHTML(operatingHours: OperatingHours): void {
     day.textContent = key;
     row.appendChild(day);
     const time = document.createElement("td");
-    time.textContent = operatingHours[key];
+    time.textContent = operatingHours[key] ?? "";
     row.appendChild(time);
     hours.appendChild(row);
   }

--- a/src/js/utils.test.ts
+++ b/src/js/utils.test.ts
@@ -86,7 +86,7 @@ describe("writeItem / getItem", () => {
     await writeItem(STORE, { id: 1, name: "Original" });
     await writeItem(STORE, { id: 1, name: "Updated" });
     const result = await getItem(STORE, 1);
-    expect(result.name).toBe("Updated");
+    expect(result?.name).toBe("Updated");
   });
 
   it("returns undefined for a missing key", async () => {
@@ -125,7 +125,7 @@ describe("deleteItem", () => {
     await deleteItem(STORE, 2);
     const result = await getItems(STORE);
     expect(result).toHaveLength(1);
-    expect(result[0].id).toBe(1);
+    expect(result[0]?.id).toBe(1);
   });
 
   it("is a no-op when the key does not exist", async () => {

--- a/src/js/utils.ts
+++ b/src/js/utils.ts
@@ -1,9 +1,19 @@
-import { openDB } from "idb";
-import type { Review } from "./types";
+import { openDB, type DBSchema } from "idb";
+import type { Restaurant, Review, ReviewDraft } from "./types";
 
+// Maps each object store to the value type it holds, so reads and writes are
+// type-checked against the store name (no per-call type arguments needed).
+interface ReviewsDB extends DBSchema {
+  restaurants: { key: number; value: Restaurant };
+  reviews: { key: number; value: Review };
+  "sync-reviews": { key: number; value: ReviewDraft };
+}
+
+// Explicit union rather than `keyof ReviewsDB` — DBSchema's base index signature
+// would otherwise widen the key type to `string`.
 export type StoreName = "restaurants" | "reviews" | "sync-reviews";
 
-const dbPromise = openDB("restaurants-store", 7, {
+const dbPromise = openDB<ReviewsDB>("restaurants-store", 7, {
   upgrade(db, oldVersion) {
     if (!db.objectStoreNames.contains("restaurants")) {
       db.createObjectStore("restaurants", { keyPath: "id" });
@@ -22,48 +32,42 @@ const dbPromise = openDB("restaurants-store", 7, {
   }
 });
 
-export async function writeItem<T>(storeName: StoreName, item: T): Promise<void> {
+export async function writeItem<K extends StoreName>(
+  storeName: K,
+  item: ReviewsDB[K]["value"]
+): Promise<void> {
   const db = await dbPromise;
-  const tx = db.transaction(storeName, "readwrite");
-  tx.objectStore(storeName).put(item);
-  return tx.done;
+  await db.put(storeName, item);
 }
 
-// `any` default: stored shapes vary by call site, and callers that care pass an
-// explicit type argument (e.g. getItems<Restaurant>). Keeps ad-hoc reads ergonomic.
-export async function getItems<T = any>(storeName: StoreName): Promise<T[]> {
+export async function getItems<K extends StoreName>(
+  storeName: K
+): Promise<ReviewsDB[K]["value"][]> {
   const db = await dbPromise;
-  return db.transaction(storeName, "readonly").objectStore(storeName).getAll() as Promise<T[]>;
+  return db.getAll(storeName);
 }
 
-export async function getItem<T = any>(
-  storeName: StoreName,
+export async function getItem<K extends StoreName>(
+  storeName: K,
   id: number | string
-): Promise<T | undefined> {
+): Promise<ReviewsDB[K]["value"] | undefined> {
   const validID = typeof id === "number" ? id : Number(id);
   const db = await dbPromise;
-  return db
-    .transaction(storeName, "readonly")
-    .objectStore(storeName)
-    .get(validID) as Promise<T | undefined>;
+  return db.get(storeName, validID);
 }
 
 export async function deleteItems(storeName: StoreName): Promise<void> {
   const db = await dbPromise;
-  const tx = db.transaction(storeName, "readwrite");
-  tx.objectStore(storeName).clear();
-  return tx.done;
+  await db.clear(storeName);
 }
 
 export async function deleteItem(storeName: StoreName, id: number): Promise<void> {
   const db = await dbPromise;
-  const tx = db.transaction(storeName, "readwrite");
-  tx.objectStore(storeName).delete(id);
-  return tx.done;
+  await db.delete(storeName, id);
 }
 
 /** A raw review as it may arrive from the API, with loosely-typed fields. */
-interface RawReview {
+export interface RawReview {
   id: number | string;
   name: unknown;
   rating: number | string;

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -8,10 +8,11 @@ import {
   deleteItems,
   writeItem,
   getItems,
-  sanitizeReview
+  sanitizeReview,
+  type RawReview
 } from "./js/utils";
 import { postReviewDirectly } from "./js/dbhelper";
-import type { ReviewDraft } from "./js/types";
+import type { Restaurant, ReviewDraft } from "./js/types";
 
 // vite-plugin-pwa injects the precache manifest by string-replacing the literal
 // `self.__WB_MANIFEST`, so that token must appear verbatim below. The SW config
@@ -87,8 +88,8 @@ registerRoute(
       if (res.ok) {
         const cloneRes = res.clone();
         deleteItems("restaurants").then(() =>
-          cloneRes.json().then(resAsJSON => {
-            resAsJSON.forEach((item: unknown) => writeItem("restaurants", item));
+          cloneRes.json().then((resAsJSON: Restaurant[]) => {
+            resAsJSON.forEach(item => writeItem("restaurants", item));
           })
         );
       }
@@ -111,7 +112,7 @@ const restaurantByIDHandler = async ({ request }: { request: Request }): Promise
       res
         .clone()
         .json()
-        .then(restaurant => writeItem("restaurants", restaurant))
+        .then((restaurant: Restaurant) => writeItem("restaurants", restaurant))
         .catch(err => console.log(err));
     }
     return res;
@@ -138,7 +139,7 @@ registerRoute(
         res
           .clone()
           .json()
-          .then((dirtyReviews: any[]) =>
+          .then((dirtyReviews: RawReview[]) =>
             dirtyReviews.map(dirtyReview => sanitizeReview(dirtyReview))
           )
           .then(cleanReviews => {
@@ -183,18 +184,20 @@ let notifiedClient = false;
 
 function syncNewReviews(): Promise<unknown> {
   notifiedClient = false;
-  return getItems<ReviewDraft & { localId: number }>("sync-reviews").then(reviews => {
-    if (reviews && reviews.length > 0) {
-      const arrOfPromises = reviews.map(review => {
-        const { localId: _localId, ...reviewBody } = review;
-        void _localId;
+  return getItems("sync-reviews").then(allDrafts => {
+    // Only drafts that have been persisted have a localId (the IDB key).
+    const reviews = allDrafts.filter(
+      (r): r is ReviewDraft & { localId: number } => r.localId !== undefined
+    );
+    if (reviews.length > 0) {
+      const arrOfPromises = reviews.map(({ localId, ...reviewBody }) => {
         return postReviewDirectly(reviewBody)
           .then(resBody => {
             console.log(`[SW] Synced review with server`, resBody);
-            return deleteItem("sync-reviews", review.localId);
+            return deleteItem("sync-reviews", localId);
           })
           .catch(err => {
-            console.log(`[SW] Error syncing review ${review.name}`, err);
+            console.log(`[SW] Error syncing review ${reviewBody.name}`, err);
             return Promise.reject(err);
           });
       });

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "forceConsistentCasingInFileNames": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noUncheckedIndexedAccess": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,20 +1,12 @@
 {
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "types": ["vite/client", "vitest/globals"],
-    "strict": true,
-    "noEmit": true,
-    "skipLibCheck": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
     "verbatimModuleSyntax": true,
-    "useDefineForClassFields": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "forceConsistentCasingInFileNames": true
+    "useDefineForClassFields": true
   },
   "include": ["src"],
   "exclude": ["src/sw.ts"]

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,17 +1,11 @@
 {
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
     "lib": ["ES2022"],
     "types": ["node"],
-    "strict": true,
-    "noEmit": true,
-    "skipLibCheck": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true
+    "esModuleInterop": true
   },
   "include": ["vite.config.ts", "vitest.config.ts", "serve.ts"]
 }

--- a/tsconfig.sw.json
+++ b/tsconfig.sw.json
@@ -1,17 +1,11 @@
 {
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
     "lib": ["ES2022", "DOM", "DOM.Iterable", "WebWorker"],
     "types": ["vite/client"],
-    "strict": true,
-    "noEmit": true,
-    "skipLibCheck": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "verbatimModuleSyntax": true,
-    "forceConsistentCasingInFileNames": true
+    "verbatimModuleSyntax": true
   },
   "include": ["src/sw.ts", "src/env.d.ts"]
 }


### PR DESCRIPTION
## What

Follow-up to the TypeScript migration: removes the remaining `any`/loose casts and raises compiler strictness. **No behavior changes.**

## Why

The migration intentionally left a few ergonomic loosenings (notably `any`-defaulted IndexedDB getters and scattered `as unknown as` row casts). This pass closes those gaps so the type system actually enforces the data shapes end-to-end.

## Changes

**Removed `any`**
- **`utils.ts`** — typed the IndexedDB layer with an `idb` `DBSchema` mapping each store to its value type (`restaurants`→`Restaurant`, `reviews`→`Review`, `sync-reviews`→`ReviewDraft`). Reads/writes are now checked against the store name, so `getItems`/`getItem` no longer default to `any` and call sites drop their manual type arguments — a wrong type per store is now a compile error. (`StoreName` is an explicit union: `keyof` a `DBSchema` collapses to `string` via its base index signature.)
- **`sw.ts`** — dropped the `any[]`; typed the `res.json()` callbacks (`Restaurant[]`, `RawReview[]`) and narrowed `localId` with a type guard instead of a cast + `void`.

**Centralized unavoidable casts**
- **`routes.ts`** — folded the eight scattered `node:sqlite` row casts (`as unknown as …`) into two typed helpers, `one<T>()` / `all<T>()`. Handlers are now assertion-free.

**Stricter compiler options** — new shared **`tsconfig.base.json`** that all four configs extend (also DRYs up the duplicated options):
- `noUncheckedIndexedAccess` — the headline. It surfaced **two real latent bugs**: `event.ports[0]` and `operating_hours[key]` could be `undefined`; both are now guarded.
- `noFallthroughCasesInSwitch`, `noImplicitOverride` — no violations.
- Deliberately skipped `exactOptionalPropertyTypes` (fights the `window.state = { map: undefined }` pattern) and `noImplicitReturns` (would force `return` on every Express `res.json()` for little gain).

## Reviewer notes

- The fallout from `noUncheckedIndexedAccess` in tests is `?.`/`!` on fixtures whose indices are known-present; the two source fixes (`event.ports[0]?.`, `operating_hours[key] ?? ""`) are genuine correctness improvements.
- `serverReviews` test fixtures gained `createdAt`/`updatedAt` so they're valid `Review` objects for the now-typed `writeItem("reviews", …)`.

## Verification

- `pnpm typecheck` — clean across app, service worker, node tooling, and server **with the new flags**
- `pnpm test` — **59/59 pass**
- `pnpm build:ui` — succeeds, SW precache manifest injected
- **Browser smoke** — home renders, favorite toggle persists (false→true), cuisine filter (11→2), Add Review (7→8, server-confirmed); no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)