### PR TITLE
build: enable type-aware ESLint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,13 +3,30 @@ import tseslint from "typescript-eslint";
 import globals from "globals";
 
 export default tseslint.config(
-  // Build output, dependencies, and the Vite-generated SW bundle.
+  // Build output, dependencies, and ambient declaration files.
   {
     ignores: ["dist/**", "**/node_modules/**", "**/*.d.ts"],
   },
 
   js.configs.recommended,
-  ...tseslint.configs.recommended,
+  ...tseslint.configs.recommendedTypeChecked,
+
+  // Type-aware linting. The repo has several tsconfigs (app / sw / node / server),
+  // so list them explicitly — the parser matches each file to the one that
+  // includes it. (`projectService` only auto-discovers the default tsconfig.json.)
+  {
+    languageOptions: {
+      parserOptions: {
+        project: [
+          "./tsconfig.json",
+          "./tsconfig.sw.json",
+          "./tsconfig.node.json",
+          "./restaurant-server/tsconfig.json",
+        ],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
 
   // Allow underscore-prefixed names to be intentionally unused (matches the
   // tsconfig noUnusedLocals/noUnusedParameters convention used in the code).
@@ -39,15 +56,31 @@ export default tseslint.config(
     languageOptions: { globals: { ...globals.browser, ...globals.serviceworker } },
   },
 
-  // Tests run under jsdom (browser-like) with Vitest.
+  // Tests run under jsdom (browser-like) with Vitest. Vitest's matcher and mock
+  // APIs (`expect.objectContaining`, `vi.fn`, ...) are intentionally typed as
+  // `any`, so the type-aware "unsafe" rules are noise here.
   {
     files: ["src/**/*.test.ts", "src/test-setup.ts"],
     languageOptions: { globals: { ...globals.browser } },
+    rules: {
+      "@typescript-eslint/no-unsafe-assignment": "off",
+      "@typescript-eslint/no-unsafe-member-access": "off",
+      "@typescript-eslint/no-unsafe-call": "off",
+      "@typescript-eslint/no-unsafe-argument": "off",
+      "@typescript-eslint/no-unsafe-return": "off",
+      "@typescript-eslint/no-explicit-any": "off",
+    },
   },
 
   // Node: the API server, the static server, and the build tooling.
   {
     files: ["restaurant-server/**/*.ts", "serve.ts", "*.config.ts"],
     languageOptions: { globals: { ...globals.node } },
+  },
+
+  // The ESLint config itself and any other JS are not part of a TS project.
+  {
+    files: ["**/*.js", "**/*.mjs", "**/*.cjs"],
+    extends: [tseslint.configs.disableTypeChecked],
   },
 );

--- a/restaurant-server/routes.ts
+++ b/restaurant-server/routes.ts
@@ -21,11 +21,32 @@ import express, { type Router } from "express";
 import type { DatabaseSync, SQLInputValue } from "node:sqlite";
 
 import type {
+  LatLng,
+  OperatingHours,
   Restaurant,
   RestaurantRow,
   Review,
   ReviewRow,
 } from "./types.ts";
+
+/** Request-body shapes accepted by the create/update endpoints (all optional). */
+interface RestaurantInput {
+  name?: string;
+  neighborhood?: string | null;
+  photograph?: string | null;
+  address?: string | null;
+  latlng?: LatLng | null;
+  cuisine_type?: string | null;
+  operating_hours?: OperatingHours | null;
+  is_favorite?: boolean;
+}
+
+interface ReviewInput {
+  restaurant_id?: number;
+  name?: string;
+  rating?: number | null;
+  comments?: string | null;
+}
 
 const now = (): string => new Date().toISOString();
 
@@ -49,9 +70,11 @@ function toRestaurant(row: RestaurantRow): Restaurant {
     neighborhood: row.neighborhood,
     photograph: row.photograph,
     address: row.address,
-    latlng: row.latlng ? JSON.parse(row.latlng) : null,
+    latlng: row.latlng ? (JSON.parse(row.latlng) as LatLng) : null,
     cuisine_type: row.cuisine_type,
-    operating_hours: row.operating_hours ? JSON.parse(row.operating_hours) : null,
+    operating_hours: row.operating_hours
+      ? (JSON.parse(row.operating_hours) as OperatingHours)
+      : null,
     is_favorite: Boolean(row.is_favorite),
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
@@ -142,7 +165,8 @@ export function createApiRouter(db: DatabaseSync): Router {
   });
 
   router.post("/restaurants", (req, res) => {
-    const { name } = req.body;
+    const body = req.body as RestaurantInput;
+    const { name } = body;
     if (!name) return res.status(400).json({ error: "`name` is required" });
 
     const ts = now();
@@ -154,13 +178,13 @@ export function createApiRouter(db: DatabaseSync): Router {
       )
       .run(
         name,
-        req.body.neighborhood ?? null,
-        req.body.photograph ?? null,
-        req.body.address ?? null,
-        JSON.stringify(req.body.latlng ?? null),
-        req.body.cuisine_type ?? null,
-        JSON.stringify(req.body.operating_hours ?? null),
-        req.body.is_favorite ? 1 : 0,
+        body.neighborhood ?? null,
+        body.photograph ?? null,
+        body.address ?? null,
+        JSON.stringify(body.latlng ?? null),
+        body.cuisine_type ?? null,
+        JSON.stringify(body.operating_hours ?? null),
+        body.is_favorite ? 1 : 0,
         ts,
         ts
       );
@@ -178,7 +202,7 @@ export function createApiRouter(db: DatabaseSync): Router {
       "restaurants",
       RESTAURANT_COLUMNS,
       Number(req.params.id),
-      req.body,
+      req.body as Record<string, unknown>,
       toRestaurant
     );
     if (!updated) return res.status(404).json({ error: "Restaurant not found" });
@@ -219,7 +243,8 @@ export function createApiRouter(db: DatabaseSync): Router {
   });
 
   router.post("/reviews", (req, res) => {
-    const { restaurant_id, name } = req.body;
+    const body = req.body as ReviewInput;
+    const { restaurant_id, name } = body;
     if (restaurant_id == null || !name) {
       return res
         .status(400)
@@ -236,8 +261,8 @@ export function createApiRouter(db: DatabaseSync): Router {
       .run(
         Number(restaurant_id),
         name,
-        req.body.rating ?? null,
-        req.body.comments ?? null,
+        body.rating ?? null,
+        body.comments ?? null,
         ts,
         ts
       );
@@ -255,7 +280,7 @@ export function createApiRouter(db: DatabaseSync): Router {
       "reviews",
       REVIEW_COLUMNS,
       Number(req.params.id),
-      req.body,
+      req.body as Record<string, unknown>,
       toReview
     );
     if (!updated) return res.status(404).json({ error: "Review not found" });

--- a/src/js/CreateReviewModal.ts
+++ b/src/js/CreateReviewModal.ts
@@ -20,14 +20,8 @@ export default class CreateReviewModal {
     // args
     this.onSubmit = onSubmit;
     this.restaurantID = restaurantID;
-    // bind methods
-    this.getFormState = this.getFormState.bind(this);
-    this.closeBtnHandler = this.closeBtnHandler.bind(this);
-    this.open = this.open.bind(this);
-    this.close = this.close.bind(this);
-    this.submitForm = this.submitForm.bind(this);
-    this.formSubmissionHandler = this.formSubmissionHandler.bind(this);
-    this.handleKeyDown = this.handleKeyDown.bind(this);
+    // (handlers passed to addEventListener are arrow-function class fields, so
+    // they're already bound to `this` — no manual .bind() needed.)
     // grab DOM
     this.modal = document.querySelector("#create-review") as HTMLElement;
     this.form = document.querySelector("#create-review-form") as HTMLFormElement;
@@ -82,10 +76,10 @@ export default class CreateReviewModal {
     }, 150);
   }
 
-  closeBtnHandler(evt: Event): void {
+  closeBtnHandler = (evt: Event): void => {
     evt.preventDefault();
     this.close();
-  }
+  };
 
   submitForm(): void {
     const postBody = this.getFormState();
@@ -116,17 +110,17 @@ export default class CreateReviewModal {
 
     this.close();
     console.log(`[App] Submitting post data`, postBody);
-    this.onSubmit(postBody);
+    void this.onSubmit(postBody);
     this.clearFormState();
   }
 
-  formSubmissionHandler(evt: Event): void {
+  formSubmissionHandler = (evt: Event): void => {
     evt.preventDefault();
     this.submitForm();
-  }
+  };
 
   // Based on https://bitsofco.de/accessible-modal-dialog/
-  handleKeyDown(e: KeyboardEvent): void {
+  handleKeyDown = (e: KeyboardEvent): void => {
     const KEY_TAB = 9;
     const KEY_ESC = 27;
     const KEY_ENTER = 13;
@@ -166,5 +160,5 @@ export default class CreateReviewModal {
       default:
         break;
     }
-  }
+  };
 }

--- a/src/js/dbhelper.ts
+++ b/src/js/dbhelper.ts
@@ -13,7 +13,9 @@ export async function fetchRestaurants(): Promise<Restaurant[]> {
     const res = await fetch(`${SERVER}/restaurants`);
     if (res.ok) {
       const data = (await res.json()) as Restaurant[];
-      data.forEach(r => writeItem("restaurants", r).catch(() => {}));
+      data.forEach(r => {
+        writeItem("restaurants", r).catch(() => {});
+      });
       return data;
     }
   } catch {
@@ -138,7 +140,9 @@ export async function fetchReviewsForRestaurant(
     const res = await fetch(`${SERVER}/reviews/?restaurant_id=${id}`);
     if (res.ok) {
       const data = (await res.json()) as Review[];
-      data.forEach(r => writeItem("reviews", r).catch(() => {}));
+      data.forEach(r => {
+        writeItem("reviews", r).catch(() => {});
+      });
       return [...data.map(r => ({ ...r, isDraft: false })), ...draftReviews];
     }
   } catch {

--- a/src/js/main.ts
+++ b/src/js/main.ts
@@ -25,16 +25,24 @@ window.state = {
   mapClosed: true
 };
 
-document.addEventListener("DOMContentLoaded", async () => {
+document.addEventListener("DOMContentLoaded", () => {
+  void initPage();
+});
+
+async function initPage(): Promise<void> {
   await Promise.all([
     updateRestaurants(),
     fetchAndFillNeighborhoods(),
     fetchAndFillCuisines()
   ]);
 
-  document.getElementById("neighborhoods-select")?.addEventListener("change", updateRestaurants);
-  document.getElementById("cuisines-select")?.addEventListener("change", updateRestaurants);
-});
+  document
+    .getElementById("neighborhoods-select")
+    ?.addEventListener("change", () => void updateRestaurants());
+  document
+    .getElementById("cuisines-select")
+    ?.addEventListener("change", () => void updateRestaurants());
+}
 
 async function fetchAndFillNeighborhoods(): Promise<void> {
   try {
@@ -67,7 +75,7 @@ async function fetchAndFillCuisines(): Promise<void> {
 }
 
 function loadMap(): void {
-  initMap(document.getElementById("map") as HTMLElement, {
+  void initMap(document.getElementById("map") as HTMLElement, {
     zoom: 12,
     center: { lat: 40.722216, lng: -73.987501 },
     scrollwheel: false
@@ -79,7 +87,7 @@ export const updateRestaurants = async (): Promise<void> => {
   try {
     const filteredRestaurants = await fetchRestaurantByCuisineAndNeighborhood(cuisine, neighborhood);
     const restaurantListMountPoint = document.getElementById("restaurants-list") as HTMLElement;
-    render(RestaurantList(filteredRestaurants, updateRestaurants), restaurantListMountPoint);
+    render(RestaurantList(filteredRestaurants, () => void updateRestaurants()), restaurantListMountPoint);
     if (window.state.map) {
       window.state.markers.forEach(m => m.remove());
       window.state.markers = [];

--- a/src/js/restaurant_info.ts
+++ b/src/js/restaurant_info.ts
@@ -31,14 +31,18 @@ function getParam(name: string): string | null {
   return new URLSearchParams(window.location.search).get(name);
 }
 
-document.addEventListener("DOMContentLoaded", async () => {
+document.addEventListener("DOMContentLoaded", () => {
+  void onReady();
+});
+
+async function onReady(): Promise<void> {
   try {
     const restaurant = await fetchRestaurantFromURL();
     fillBreadcrumb(restaurant);
   } catch (e) {
     console.error(e);
   }
-  fetchReviewsFromURL();
+  void fetchReviewsFromURL();
 
   const CRM = new CreateReviewModal({
     restaurantID: getParam("id"),
@@ -54,7 +58,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         window.state.reviews = reviews;
       } else {
         // Offline (background sync): draft is now in IDB — re-fetch to show it immediately
-        fetchReviewsFromURL();
+        void fetchReviewsFromURL();
       }
     }
   });
@@ -65,7 +69,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     navigator.serviceWorker.addEventListener("message", event => {
       event.ports[0]?.postMessage("ACK");
       if (event.data === "refresh") {
-        fetchReviewsFromURL();
+        void fetchReviewsFromURL();
       }
     });
 
@@ -89,12 +93,12 @@ document.addEventListener("DOMContentLoaded", async () => {
       toggleMapBtn.setAttribute("aria-pressed", "false");
     }
   });
-});
+}
 
 function loadMap(): void {
   const restaurant = window.state.restaurant;
   if (!restaurant?.latlng) return;
-  initMap(document.getElementById("map") as HTMLElement, {
+  void initMap(document.getElementById("map") as HTMLElement, {
     zoom: 16,
     center: restaurant.latlng,
     scrollwheel: false

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -38,6 +38,9 @@ interface SyncEvent extends ExtendableEvent {
   readonly lastChance: boolean;
 }
 
+/** Normalize an unknown thrown value into an `Error` for promise rejection. */
+const toError = (e: unknown): Error => (e instanceof Error ? e : new Error(String(e)));
+
 const SERVER = import.meta.env.API_SERVER || "http://localhost:1337";
 const SERVER_ORIGIN = new URL(SERVER).origin;
 
@@ -87,16 +90,18 @@ registerRoute(
       const res = await fetch(request);
       if (res.ok) {
         const cloneRes = res.clone();
-        deleteItems("restaurants").then(() =>
+        void deleteItems("restaurants").then(() =>
           cloneRes.json().then((resAsJSON: Restaurant[]) => {
-            resAsJSON.forEach(item => writeItem("restaurants", item));
+            resAsJSON.forEach(item => {
+              void writeItem("restaurants", item);
+            });
           })
         );
       }
       return res;
     } catch (err) {
       console.log(err);
-      return Promise.reject(err);
+      return Promise.reject(toError(err));
     }
   }
 );
@@ -118,7 +123,7 @@ const restaurantByIDHandler = async ({ request }: { request: Request }): Promise
     return res;
   } catch (err) {
     console.log(err);
-    return Promise.reject(err);
+    return Promise.reject(toError(err));
   }
 };
 
@@ -136,20 +141,22 @@ registerRoute(
     try {
       const res = await fetch(request);
       if (res.ok) {
-        res
+        void res
           .clone()
           .json()
           .then((dirtyReviews: RawReview[]) =>
             dirtyReviews.map(dirtyReview => sanitizeReview(dirtyReview))
           )
           .then(cleanReviews => {
-            cleanReviews.forEach(review => writeItem("reviews", review));
+            cleanReviews.forEach(review => {
+              void writeItem("reviews", review);
+            });
           });
       }
       return res;
     } catch (err) {
       console.log(err);
-      return Promise.reject(err);
+      return Promise.reject(toError(err));
     }
   },
   "GET"
@@ -159,10 +166,11 @@ function send_message_to_client(client: Client, msg: string): Promise<unknown> {
   return new Promise((resolve, reject) => {
     const msg_chan = new MessageChannel();
     msg_chan.port1.onmessage = (event: MessageEvent) => {
-      if (event.data.error) {
-        reject(event.data.error);
+      const data = event.data as { error?: unknown };
+      if (data.error) {
+        reject(toError(data.error));
       } else {
-        resolve(event.data);
+        resolve(data);
       }
     };
     client.postMessage(msg, [msg_chan.port2]);
@@ -172,8 +180,8 @@ function send_message_to_client(client: Client, msg: string): Promise<unknown> {
 function send_message_to_all_clients(msg: string): Promise<void> {
   return swScope.clients.matchAll().then(clients => {
     clients.forEach(client => {
-      send_message_to_client(client, msg).then(m =>
-        console.log(`[SW]: Received message from client ` + m)
+      void send_message_to_client(client, msg).then(m =>
+        console.log(`[SW]: Received message from client ` + String(m))
       );
     });
   });
@@ -198,19 +206,19 @@ function syncNewReviews(): Promise<unknown> {
           })
           .catch(err => {
             console.log(`[SW] Error syncing review ${reviewBody.name}`, err);
-            return Promise.reject(err);
+            return Promise.reject(toError(err));
           });
       });
       setTimeout(() => {
         if (!notifiedClient) {
-          send_message_to_all_clients("refresh");
+          void send_message_to_all_clients("refresh");
           notifiedClient = true;
         }
       }, SUBMIT_REVIEWS_TIMEOUT);
       return Promise.all(arrOfPromises)
         .then(res => {
           console.log(`[SW] Successfully synced all reviews to server`);
-          send_message_to_all_clients("refresh");
+          void send_message_to_all_clients("refresh");
           notifiedClient = true;
           return Promise.resolve(res);
         })
@@ -220,11 +228,11 @@ function syncNewReviews(): Promise<unknown> {
               ? `[SW] Unable to sync reviews with server. This is probably because you are offline`
               : `[SW] Unable to sync reviews with server due to an unknown error. Please contact the developer with the following error message: ${err}`;
           if (!notifiedClient) {
-            send_message_to_all_clients("refresh");
+            void send_message_to_all_clients("refresh");
             notifiedClient = true;
           }
           console.log(humanFriendlyErrorMessage);
-          return Promise.reject(humanFriendlyErrorMessage);
+          return Promise.reject(new Error(humanFriendlyErrorMessage));
         });
     } else {
       console.log(`[SW] No reviews to sync`);


### PR DESCRIPTION
## What

Tightens the linter: upgrades from the non-type-checked `recommended` preset to **`recommendedTypeChecked`**, and fixes all 58 resulting findings. **No behavior changes.**

## Why

Type-aware linting catches whole classes of correctness bugs that `tsc --strict` and the basic preset can't — floating promises, async functions passed where a `void` handler is expected, and `any` values flowing into typed APIs. These are exactly the rough edges in a PWA that does a lot of fire-and-forget IO.

## Config changes

- `recommendedTypeChecked`, with `parserOptions.project` listing all four tsconfigs. (`projectService` only auto-discovers the default `tsconfig.json`, which left the service worker, build tooling, and server files unparsed.)
- `disableTypeChecked` for plain JS (the ESLint config file itself).
- Test-only relaxation of the `no-unsafe-*` family — Vitest's `expect.objectContaining`/`vi.fn` are typed `any` by design, so those rules are pure noise in tests.

## Source fixes (all behavior-preserving)

- **Floating promises** → explicit `void` on fire-and-forget calls (SW IDB side-effects, page init, review refetch, map init).
- **Misused promises** → async event handlers / callbacks wrapped so the promise is handled (`addEventListener`, `forEach`, the favorite-toggle callback).
- **Unsafe `any`** → typed the Express `req.body` via `RestaurantInput`/`ReviewInput`, and cast `JSON.parse` results in the row mappers.
- **unbound-method** → converted `CreateReviewModal`'s event-handler methods to arrow-function class fields and removed the manual `.bind()` calls (cleaner and inherently bound).
- **prefer-promise-reject-errors** → reject with `Error` (small `toError` helper) instead of caught `unknown`/strings.
- **restrict-plus-operands / unsafe-member-access** → `String(...)` the SW client message and typed the `MessageEvent.data` payload.

## Reviewer notes

- The biggest behavioral-looking change is `CreateReviewModal` switching from `.bind()` to arrow class fields — semantically identical (both bind `this`), and verified working in the browser.
- `req.body` typing is a genuine improvement: the create/update handlers now have a typed view of their input instead of `any`.

## Verification

- `pnpm lint` — **clean** (type-aware)
- `pnpm typecheck` — clean
- `pnpm test` — **59/59**
- `pnpm build:ui` — succeeds, SW manifest injected
- **Browser smoke** — favorite toggle, cuisine filter, and the full Add Review modal (open → close → submit, via the refactored handlers) all work; no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)