### PR TITLE
fix: remove duplicate semver@7.8.4 entries in pnpm-lock.yaml

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2883,11 +2883,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  semver@7.8.4:
-    resolution: {integrity: sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   send@1.2.1:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
@@ -6264,8 +6259,6 @@ snapshots:
       xmlchars: 2.2.0
 
   semver@6.3.1: {}
-
-  semver@7.8.4: {}
 
   semver@7.8.4: {}
 


### PR DESCRIPTION
## Summary

- The `pnpm-lock.yaml` was left with duplicate `semver@7.8.4` entries (both in the packages section and the snapshots section) after the vite-imagetools bump merged in #110.
- pnpm treats duplicate YAML keys as a broken lockfile (`ERR_PNPM_BROKEN_LOCKFILE`), failing CI with exit code 1 before any tests run.
- Fix: remove the 7 duplicate lines (1 blank + 4 content in packages; 1 blank + 1 `{}` in snapshots).

## Test plan

- [ ] CI passes on this PR with `pnpm install --frozen-lockfile` succeeding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)