### PR TITLE
fix: set secure cookie flags on session (CodeQL js/clear-text-cookie)

### DIFF
--- a/restaurant-server/app.ts
+++ b/restaurant-server/app.ts
@@ -16,6 +16,8 @@
  *                   production to lock the API down.
  *   SESSION_SECRET  Secret used to sign the session cookie.  Default: insecure
  *                   Set a real value in production.          dev fallback
+ *   NODE_ENV        Set to "production" to enable the        Default: unset
+ *                   Secure flag on the session cookie.
  */
 
 import express, {
@@ -83,6 +85,11 @@ app.use(
     secret: SESSION_SECRET || "insecure-dev-secret",
     resave: false,
     saveUninitialized: false,
+    cookie: {
+      secure: process.env.NODE_ENV === "production",
+      httpOnly: true,
+      sameSite: "lax",
+    },
   })
 );
 


### PR DESCRIPTION
## Summary

Fixes CodeQL alert [#2](https://github.com/bushidocodes/restaurant-review-site/security/code-scanning/2) — `js/clear-text-cookie`.

The `express-session` cookie in `restaurant-server/app.ts` had no `secure`, `httpOnly`, or `sameSite` attributes, allowing the session cookie to be sent over plain HTTP and read by client-side scripts.

**Changes to `restaurant-server/app.ts`:**
- `httpOnly: true` — prevents client-side JS from reading the cookie
- `sameSite: "lax"` — blocks the cookie from being sent on cross-site requests
- `secure: process.env.NODE_ENV === "production"` — requires HTTPS in production while keeping plain HTTP working in local dev

Also documents `NODE_ENV` in the top-of-file configuration comment.

## Test plan

- [ ] CI passes (typecheck + existing tests)
- [ ] CodeQL re-scan should close alert #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)