### PR TITLE
fix: add least-privilege permissions to CI workflow (CodeQL actions/missing-workflow-permissions)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [master]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Fixes CodeQL alert [#5](https://github.com/bushidocodes/restaurant-review-site/security/code-scanning/5) — `actions/missing-workflow-permissions`.

The CI workflow had no explicit `permissions` block, meaning it inherited the repository default (potentially read-write). Added `permissions: contents: read` at the workflow level — the minimum required for `actions/checkout`. The workflow performs no writes (no pushes, no PR creation, no package publishing), so no additional permissions are needed.

## Test plan

- [ ] CI passes on this PR
- [ ] CodeQL re-scan should close alert #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)