### PR TITLE
fix(deps): bump undici to 7.28.0 to resolve Dependabot #421 and #422

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3056,8 +3056,8 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici@7.27.2:
-    resolution: {integrity: sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
@@ -5639,7 +5639,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.27.2
+      undici: 7.28.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -6430,7 +6430,7 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  undici@7.27.2: {}
+  undici@7.28.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 


### PR DESCRIPTION
## Summary

Resolves both open `undici` Dependabot alerts with a single in-range, lockfile-only bump:

- [#422](https://github.com/bushidocodes/restaurant-review-site/security/dependabot/422) — **high** — CVE-2026-9697, `GHSA-vmh5-mc38-953g`: SOCKS5 `ProxyAgent` silently drops `requestTls`, bypassing TLS certificate validation
- [#421](https://github.com/bushidocodes/restaurant-review-site/security/dependabot/421) — **medium** — CVE-2026-9678, `GHSA-pr7r-676h-xcf6`: shared-cache whitespace bypass leaks cross-user `Authorization` responses

Both are patched in undici **7.28.0**.

## Dependency analysis

`undici` is a **transitive dev dependency** — nothing in this project imports it directly:

```
undici@7.27.2  (was)
└─┬ jsdom@29.1.1        (devDependency — vitest test environment)
  └── vitest@4.1.8
```

- jsdom@29.1.1 declares `undici@^7.25.0`, so **7.28.0 satisfies the existing range** — no jsdom change needed.
- The other patched line, 8.5.0, is a major bump that jsdom's `^7.25.0` would reject, so staying on **7.28.0** is the correct, minimal fix.
- `pnpm update undici -r` produced a clean lockfile-only diff (undici `7.27.2 → 7.28.0` plus its integrity hash); no other packages moved.

### Real-world exposure
Both CVEs require runtime features this project never exercises (a SOCKS5 `ProxyAgent` with `requestTls`; the shared-mode cache interceptor forwarding `Authorization`). undici is only present here as jsdom's fetch backend during tests. Severity in this repo is therefore low — but since a clean in-range patch exists, bumping is strictly better than dismissing.

## Test plan

- `pnpm install --frozen-lockfile` — clean, already up to date
- `pnpm test` — **59/59 passing** under the jsdom environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)