### PR TITLE
chore: add packageManager field (pnpm@11.5.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,6 @@ jobs:
           node-version-file: .node-version
 
       - uses: pnpm/action-setup@v6
-        with:
-          version: 11
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "mws-restaurant-stage-1",
   "version": "1.0.0",
+  "packageManager": "pnpm@11.5.0",
   "description": "--- #### _Three Stage Course Material Project - Restaurant Reviews_",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## Summary
Add `packageManager": "pnpm@11.5.0"` to `package.json` so Corepack / `pnpm/action-setup` can resolve the pnpm version without a workflow-only pin.

## Why
Matches the portfolio standard (e.g. `chord-grpc`, `keypunch`) and avoids "No pnpm version is specified" failures when action-setup relies on package.json.